### PR TITLE
Try to split Data and Protocol Client Versions

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -8,6 +8,7 @@ struct Config
     string Login;
     string Password;
     string ClientVersionString = "7.0.33.1";
+    string ProtocolClientVersionString = "7.0.33.1";
     string CustomPath;
     string ServerAddress;
     uint16_t ServerPort = 2593;
@@ -25,6 +26,7 @@ struct Config
     uint32_t Key2 = 0;
     uint32_t Key3 = 0;
     uint32_t ClientVersion = CV_LATEST;
+    uint32_t ProtocolClientVersion = CV_LATEST;
     uint32_t EncryptionType = 0;
 };
 

--- a/src/CrossUO.cpp
+++ b/src/CrossUO.cpp
@@ -1947,12 +1947,12 @@ void CGame::LoginComplete(bool reload)
 
         //CPacketOpenChat({}).Send();
         //CPacketRazorAnswer().Send();
-        if (g_Config.ClientVersion >= CV_306E)
+        if (g_Config.ProtocolClientVersion >= CV_306E)
         {
             CPacketClientType().Send();
         }
 
-        if (g_Config.ClientVersion >= CV_305D)
+        if (g_Config.ProtocolClientVersion >= CV_305D)
         {
             CPacketClientViewRange(g_ConfigManager.UpdateRange).Send();
         }
@@ -6503,7 +6503,7 @@ void CGame::DropItem(int container, uint16_t x, uint16_t y, char z)
     DEBUG_TRACE_FUNCTION;
     if (g_ObjectInHand.Enabled && g_ObjectInHand.Serial != container)
     {
-        if (g_Config.ClientVersion >= CV_6017)
+        if (g_Config.ProtocolClientVersion >= CV_6017)
         {
             CPacketDropRequestNew(g_ObjectInHand.Serial, x, y, z, 0, container).Send();
         }

--- a/src/Managers/PacketManager.cpp
+++ b/src/Managers/PacketManager.cpp
@@ -2250,7 +2250,8 @@ PACKET_HANDLER(OpenPaperdoll)
 PACKET_HANDLER(ClientVersion)
 {
     DEBUG_TRACE_FUNCTION;
-    CPacketClientVersion(g_Config.ClientVersionString).Send(); // Send client data version instead protocol version
+    CPacketClientVersion(g_Config.ClientVersionString)
+        .Send(); // Send client data version instead protocol version
 }
 
 PACKET_HANDLER(Ping)
@@ -5825,8 +5826,8 @@ PACKET_HANDLER(OpenBook) // 0x93
     uint8_t flags = ReadUInt8();
     Move(1);
     auto pageCount = ReadUInt16BE();
-    CGumpBook *gump =
-        new CGumpBook(serial, 0, 0, pageCount, flags != 0, (g_Config.ProtocolClientVersion >= CV_308Z));
+    CGumpBook *gump = new CGumpBook(
+        serial, 0, 0, pageCount, flags != 0, (g_Config.ProtocolClientVersion >= CV_308Z));
 
     gump->m_EntryTitle->m_Entry.SetTextA(ReadString(60));
     gump->m_EntryAuthor->m_Entry.SetTextA(ReadString(30));

--- a/src/Managers/PacketManager.cpp
+++ b/src/Managers/PacketManager.cpp
@@ -619,7 +619,7 @@ void CPacketManager::SendMegaClilocRequests()
     DEBUG_TRACE_FUNCTION;
     if (g_TooltipsEnabled && !m_MegaClilocRequests.empty())
     {
-        if (g_Config.ClientVersion >= CV_500A)
+        if (g_Config.ProtocolClientVersion >= CV_500A)
         {
             while (!m_MegaClilocRequests.empty())
             {
@@ -822,7 +822,7 @@ PACKET_HANDLER(CharacterList)
     HandleResendCharacterList();
     uint8_t locCount = ReadUInt8();
     g_CityList.Clear();
-    if (g_Config.ClientVersion >= CV_70130)
+    if (g_Config.ProtocolClientVersion >= CV_70130)
     {
         for (int i = 0; i < locCount; i++)
         {
@@ -867,7 +867,7 @@ PACKET_HANDLER(CharacterList)
     //g_SendLogoutNotification = (bool)(g_ClientFlag & LFF_RE);
     g_PopupEnabled = (bool)(g_ClientFlag & CLF_CONTEXT_MENU);
     g_TooltipsEnabled =
-        (bool)(((g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS) != 0u) && (g_Config.ClientVersion >= CV_308Z));
+        (bool)(((g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS) != 0u) && (g_Config.ProtocolClientVersion >= CV_308Z));
     g_PaperdollBooks = (bool)(g_ClientFlag & CLF_PALADIN_NECROMANCER_TOOLTIPS);
 
     g_CharacterListScreen.UpdateContent();
@@ -1037,14 +1037,14 @@ PACKET_HANDLER(EnterWorld)
     g_LastSpellIndex = 1;
     g_LastSkillIndex = 1;
 
-    CPacketClientVersion(g_Config.ClientVersionString).Send();
+    CPacketClientVersion(g_Config.ProtocolClientVersionString).Send();
 
-    if (g_Config.ClientVersion >= CV_200)
+    if (g_Config.ProtocolClientVersion >= CV_200)
     {
         CPacketGameWindowSize().Send();
     }
 
-    if (g_Config.ClientVersion >= CV_200)
+    if (g_Config.ProtocolClientVersion >= CV_200)
     {
         CPacketLanguage(g_Language).Send();
     }
@@ -1173,7 +1173,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
         return;
     }
 
-    if (*Start == 0x16 && g_Config.ClientVersion < CV_500A)
+    if (*Start == 0x16 && g_Config.ProtocolClientVersion < CV_500A)
     {
         return;
     }
@@ -1196,7 +1196,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
             uint8_t poisonFlag = 0x04;
             if (enable != 0u)
             {
-                if (g_Config.ClientVersion >= CV_7000)
+                if (g_Config.ProtocolClientVersion >= CV_7000)
                 {
                     obj->SA_Poisoned = true;
                 }
@@ -1207,7 +1207,7 @@ PACKET_HANDLER(NewHealthbarUpdate)
             }
             else
             {
-                if (g_Config.ClientVersion >= CV_7000)
+                if (g_Config.ProtocolClientVersion >= CV_7000)
                 {
                     obj->SA_Poisoned = false;
                 }
@@ -1373,7 +1373,7 @@ PACKET_HANDLER(CharacterStatus)
             }
             else
             {
-                if (g_Config.ClientVersion >= CV_500A)
+                if (g_Config.ProtocolClientVersion >= CV_500A)
                 {
                     g_Player->MaxWeight = 7 * (g_Player->Str / 2) + 40;
                 }
@@ -1664,7 +1664,7 @@ PACKET_HANDLER(UpdateObject)
         uint8_t layer = ReadUInt8();
         uint16_t itemColor = 0;
 
-        if (g_Config.ClientVersion >= CV_70331)
+        if (g_Config.ProtocolClientVersion >= CV_70331)
         {
             itemColor = ReadUInt16BE();
         }
@@ -1779,7 +1779,7 @@ PACKET_HANDLER(UpdateContainedItem)
     uint16_t x = ReadUInt16BE();
     uint16_t y = ReadUInt16BE();
 
-    if (g_Config.ClientVersion >= CV_6017)
+    if (g_Config.ProtocolClientVersion >= CV_6017)
     {
         Move(1);
     }
@@ -1810,7 +1810,7 @@ PACKET_HANDLER(UpdateContainedItems)
         uint16_t x = ReadUInt16BE();
         uint16_t y = ReadUInt16BE();
 
-        if (g_Config.ClientVersion >= CV_6017)
+        if (g_Config.ProtocolClientVersion >= CV_6017)
         {
             Move(1);
         }
@@ -2250,7 +2250,7 @@ PACKET_HANDLER(OpenPaperdoll)
 PACKET_HANDLER(ClientVersion)
 {
     DEBUG_TRACE_FUNCTION;
-    CPacketClientVersion(g_Config.ClientVersionString).Send();
+    CPacketClientVersion(g_Config.ClientVersionString).Send(); // Send client data version instead protocol version
 }
 
 PACKET_HANDLER(Ping)
@@ -2362,7 +2362,7 @@ PACKET_HANDLER(LightLevel)
 PACKET_HANDLER(EnableLockedFeatures)
 {
     DEBUG_TRACE_FUNCTION;
-    if (g_Config.ClientVersion >= CV_60142)
+    if (g_Config.ProtocolClientVersion >= CV_60142)
     {
         g_LockedClientFeatures = ReadUInt32BE();
     }
@@ -3977,7 +3977,8 @@ PACKET_HANDLER(AssistVersion)
 {
     DEBUG_TRACE_FUNCTION;
     uint32_t version = ReadUInt32BE();
-    CPacketAssistVersion(version, g_Config.ClientVersionString).Send();
+    // CHECK: if this is correct for the use case where ClientVersion != ProtocolClientVersion
+    CPacketAssistVersion(version, g_Config.ProtocolClientVersionString).Send();
 }
 
 PACKET_HANDLER(CharacterListNotification)
@@ -5526,7 +5527,7 @@ PACKET_HANDLER(DisplayMap)
 
     CGumpMap *gump = new CGumpMap(serial, gumpid, startX, startY, endX, endY, width, height);
 
-    if (*Start == 0xF5 || g_Config.ClientVersion >= CV_308Z) //308z или выше?
+    if (*Start == 0xF5 || g_Config.ProtocolClientVersion >= CV_308Z) //308z или выше?
     {
         uint16_t facet = 0;
 
@@ -5825,7 +5826,7 @@ PACKET_HANDLER(OpenBook) // 0x93
     Move(1);
     auto pageCount = ReadUInt16BE();
     CGumpBook *gump =
-        new CGumpBook(serial, 0, 0, pageCount, flags != 0, (g_Config.ClientVersion >= CV_308Z));
+        new CGumpBook(serial, 0, 0, pageCount, flags != 0, (g_Config.ProtocolClientVersion >= CV_308Z));
 
     gump->m_EntryTitle->m_Entry.SetTextA(ReadString(60));
     gump->m_EntryAuthor->m_Entry.SetTextA(ReadString(30));

--- a/src/Managers/PluginManager.cpp
+++ b/src/Managers/PluginManager.cpp
@@ -61,7 +61,7 @@ CPlugin::CPlugin(uint32_t flags)
     m_PPS = new PLUGIN_INTERFACE();
     memset(m_PPS, 0, sizeof(PLUGIN_INTERFACE));
     m_PPS->Handle = g_GameWindow.Handle;
-    m_PPS->ClientVersion = g_Config.ClientVersion;
+    m_PPS->ClientVersion = g_Config.ProtocolClientVersion; // CHECK
     m_PPS->ClientFlags = (g_Config.UseVerdata ? 0x01 : 0);
 }
 

--- a/src/Managers/ProfessionManager.cpp
+++ b/src/Managers/ProfessionManager.cpp
@@ -347,7 +347,7 @@ bool CProfessionManager::Load()
         apc->SetSkillIndex(2, 0xFF);
         apc->SetSkillIndex(3, 0xFF);
 
-        if (g_Config.ClientVersion >= CV_70160)
+        if (g_Config.ProtocolClientVersion >= CV_70160)
         {
             apc->Str = 45;
             apc->Int = 35;

--- a/src/Managers/SpeechManager.cpp
+++ b/src/Managers/SpeechManager.cpp
@@ -193,7 +193,7 @@ bool CSpeechManager::LoadLangCodes()
 void CSpeechManager::GetKeywords(const wchar_t *text, vector<uint32_t> &codes)
 {
     DEBUG_TRACE_FUNCTION;
-    if (!m_Loaded || g_Config.ClientVersion < CV_305D)
+    if (!m_Loaded || g_Config.ProtocolClientVersion < CV_305D)
     {
         return; // But in fact from the client version 2.0.7
     }

--- a/src/Network/Packets.cpp
+++ b/src/Network/Packets.cpp
@@ -85,7 +85,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     int skillsCount = 3;
     uint32_t packetID = 0x00;
 
-    if (g_Config.ClientVersion >= CV_70160)
+    if (g_Config.ProtocolClientVersion >= CV_70160)
     {
         skillsCount++;
         Resize(106, true);
@@ -117,7 +117,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     WriteUInt8(val); //profession
     Move(15);        //?
 
-    if (g_Config.ClientVersion < CV_4011D)
+    if (g_Config.ProtocolClientVersion < CV_4011D)
     {
         val = (uint8_t)g_CreateCharacterManager.GetFemale();
     }
@@ -125,7 +125,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     {
         val = (uint8_t)g_CreateCharacterManager.GetRace();
 
-        if (g_Config.ClientVersion < CV_7000)
+        if (g_Config.ProtocolClientVersion < CV_7000)
         {
             val--;
         }
@@ -162,7 +162,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
     WriteUInt16BE(g_CreateCharacterManager.GetBeard(g_CreateCharacterManager.BeardStyle).GraphicID);
     WriteUInt16BE(g_CreateCharacterManager.BeardColor);
 
-    if (g_Config.ClientVersion >= CV_70160)
+    if (g_Config.ProtocolClientVersion >= CV_70160)
     {
         uint16_t location = g_SelectTownScreen.m_City->LocationIndex;
 
@@ -194,7 +194,7 @@ CPacketCreateCharacter::CPacketCreateCharacter(const string &name)
         WriteUInt8(serverIndex); //server index
 
         uint8_t location = g_SelectTownScreen.m_City->LocationIndex;
-        if (g_Config.ClientVersion < CV_70130)
+        if (g_Config.ProtocolClientVersion < CV_70130)
         {
             location--;
         }
@@ -474,7 +474,7 @@ CPacketUnicodeSpeechRequest::CPacketUnicodeSpeechRequest(
 CPacketCastSpell::CPacketCastSpell(int index)
     : CPacket(1)
 {
-    if (g_Config.ClientVersion >= CV_60142)
+    if (g_Config.ProtocolClientVersion >= CV_60142)
     {
         Resize(9, true);
 


### PR DESCRIPTION
This is confusing, and the use case is a bit weird and a special case.
Anything that may impact how the client iteract with the server uses Protocol
client version.
Anything related to loading data and interpreting files local in the user client
are Client version.
For normal use cases, this split should not have an impact as if Protocol
version is not set, then Client version will be used automatically.