### PR TITLE
Fixes #19 - Add `Language` override option to crossuo.cfg

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -33,6 +33,7 @@ enum
     MSCC_USE_CRYPT,
     MSCC_USE_VERDATA,
     MSCC_CLIENT_TYPE,
+    MSCC_LOCALE_OVERRIDE,
     MSCC_COUNT,
 };
 
@@ -65,6 +66,7 @@ static const ConfigEntry s_Keys[] = {
     { MSCC_USE_CRYPT, "crypt" },
     { MSCC_USE_VERDATA, "useverdata" },
     { MSCC_CLIENT_TYPE, "clienttype" },
+    { MSCC_LOCALE_OVERRIDE, "language" },
     { MSCC_COUNT, nullptr },
 };
 
@@ -441,6 +443,11 @@ void LoadGlobalConfig()
                     }
                     break;
                 }
+                case MSCC_LOCALE_OVERRIDE:
+                {
+                    g_Config.LocaleOverride = ToUpperA(strings[1]);
+                }
+                break;
                 default:
                     break;
             }
@@ -515,6 +522,11 @@ void SaveGlobalConfig()
     if (s_Mark.UseVerdata)
     {
         fprintf(cfg, "UseVerdata=%s\n", (g_Config.UseVerdata ? "yes" : "no"));
+    }
+
+    if (!g_Config.LocaleOverride.empty())
+    {
+        fprintf(cfg, "Language=%s\n", g_Config.LocaleOverride.c_str());
     }
 
     fprintf(cfg, "Crypt=%s\n", (g_Config.UseCrypt ? "yes" : "no"));

--- a/src/Config.h
+++ b/src/Config.h
@@ -11,6 +11,7 @@ struct Config
     string ProtocolClientVersionString = "7.0.33.1";
     string CustomPath;
     string ServerAddress;
+    string LocaleOverride;
     uint16_t ServerPort = 2593;
     uint16_t ClientFlag = 0;
     bool SavePassword = false;

--- a/src/CrossUO.cpp
+++ b/src/CrossUO.cpp
@@ -399,7 +399,14 @@ bool CGame::Install()
         g_MapBlockSize[i].Height = g_MapSize[i].Height / 8;
     }
 
-    Platform::SetLanguageFromSystemLocale();
+    if (g_Config.LocaleOverride.empty())
+    {
+        Platform::SetLanguageFromSystemLocale();
+    }
+    else
+    {
+        g_Language = g_Config.LocaleOverride;
+    }
     fs_path_create(g_App.ExeFilePath("screenshots"));
 
     LOG("Client config loaded!\n");


### PR DESCRIPTION
Language is a 3 letter code based on UO files (ENU, FRA, etc.)