### PR TITLE
Fix for Html Gump text entry limited issues

### DIFF
--- a/src/Managers/PacketManager.cpp
+++ b/src/Managers/PacketManager.cpp
@@ -5154,7 +5154,7 @@ PACKET_HANDLER(OpenGump)
 
                 gump->Add(new CGUIHitBox(index + 1, x, y, width, height));
                 gump->Add(new CGUIScissor(true, x, y, 0, 0, width, height));
-                go = new CGUIGenericTextEntry(index + 1, textIndex, color, x, y, width, length);
+                go = new CGUIGenericTextEntry(index + 1, textIndex, color, x, y, 0, length);
                 ((CGUIGenericTextEntry *)go)->CheckOnSerial = true;
                 ((CGUITextEntry *)go)->m_Entry.Width = width;
                 if (!EntryChanged)


### PR DESCRIPTION
Fix for isuuses #16 
Remove the width limit keep the length limit 
![capture d ecran 2019-02-17 a 01 49 59](https://user-images.githubusercontent.com/359353/52909449-8fa45a80-3256-11e9-902f-2af308681089.png)
textentrylimited x y width height color id startstringindex limit