### PR TITLE
Fixes #56 - Correct status bar tooltip positions

### DIFF
--- a/src/Gumps/GumpOptions.cpp
+++ b/src/Gumps/GumpOptions.cpp
@@ -2052,7 +2052,7 @@ void CGumpOptions::DrawPage5()
     button->ProcessPressedState = true;
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 134, 82));
-    text->CreateTextureW(0, L"Keystroke");
+    text->CreateTextureW(1, L"Keystroke");
 
     //KeyBox
     Add(new CGUIGumppic(0x098B, 133, 112));
@@ -2062,7 +2062,7 @@ void CGumpOptions::DrawPage5()
     m_MacroKey->CheckOnSerial = true;
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 200, 111));
-    text->CreateTextureW(0, L"Key");
+    text->CreateTextureW(1, L"Key");
 
     //Shift checkbox
     m_MacroCheckboxShift = (CGUICheckbox *)Add(
@@ -2070,7 +2070,7 @@ void CGumpOptions::DrawPage5()
     m_MacroCheckboxShift->GraphicSelected = 0x0868;
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 280, 82));
-    text->CreateTextureW(0, L"Shift");
+    text->CreateTextureW(1, L"Shift");
 
     //Alt checkbox
     m_MacroCheckboxAlt = (CGUICheckbox *)Add(
@@ -2078,7 +2078,7 @@ void CGumpOptions::DrawPage5()
     m_MacroCheckboxAlt->GraphicSelected = 0x0868;
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 280, 111));
-    text->CreateTextureW(0, L"Alt");
+    text->CreateTextureW(1, L"Alt");
 
     //Ctrl checkbox
     m_MacroCheckboxCtrl = (CGUICheckbox *)Add(
@@ -2086,10 +2086,10 @@ void CGumpOptions::DrawPage5()
     m_MacroCheckboxCtrl->GraphicSelected = 0x0868;
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 280, 140));
-    text->CreateTextureW(0, L"Ctrl");
+    text->CreateTextureW(1, L"Ctrl");
 
     text = (CGUIText *)Add(new CGUIText(g_OptionsTextColor, 134, 163));
-    text->CreateTextureW(0, L"Actions");
+    text->CreateTextureW(1, L"Actions");
 
     m_MacroDataBox = (CGUIDataBox *)Add(new CGUIDataBox());
 }

--- a/src/Gumps/GumpSelectFont.cpp
+++ b/src/Gumps/GumpSelectFont.cpp
@@ -5,6 +5,8 @@
 #include "../Managers/FontsManager.h"
 #include "../Managers/ConfigManager.h"
 
+static const int ID_GSF_FONTS = 1;
+
 CGumpSelectFont::CGumpSelectFont(uint32_t serial, short x, short y, SELECT_FONT_GUMP_STATE state)
     : CGump(GT_SELECT_FONT, serial, x, y)
     , m_State(state)
@@ -21,10 +23,8 @@ void CGumpSelectFont::UpdateContent()
     Clear();
 
     CGUIResizepic *background = (CGUIResizepic *)Add(new CGUIResizepic(0, 0x0A28, 0, 0, 200, 70));
-
     CGUIText *text = (CGUIText *)Add(new CGUIText(0, 60, 22));
-    text->CreateTextureW(0, L"Select font");
-
+    text->CreateTextureW(0, L"Select Font");
     auto selected = 0;
     switch (m_State)
     {
@@ -47,11 +47,9 @@ void CGumpSelectFont::UpdateContent()
             break;
     }
 
-    int drawY = 46;
-
     Add(new CGUIGroup(1));
+    int drawY = 46;
     int count = 0;
-
     for (int i = 0; i < 20; i++)
     {
         if (g_FontManager.UnicodeFontExists(i))
@@ -59,14 +57,12 @@ void CGumpSelectFont::UpdateContent()
             CGUIRadio *radio = (CGUIRadio *)Add(
                 new CGUIRadio((int)i + ID_GSF_FONTS, 0x00D0, 0x00D1, 0x00D0, 50, drawY));
             radio->Checked = (i == selected);
-            radio->SetTextParameters((uint8_t)i, L"This font", 0);
+            radio->SetTextParameters((uint8_t)i, L"This Font", 0);
             drawY += 22;
             count++;
         }
     }
-
     background->Height = 70 + (count * 22);
-
     Add(new CGUIGroup(0));
 }
 
@@ -80,7 +76,6 @@ void CGumpSelectFont::GUMP_RADIO_EVENT_C
 
     int realFont = -1;
     int count = serial - ID_GSF_FONTS;
-
     for (int i = 0; i < 20; i++)
     {
         if (g_FontManager.UnicodeFontExists(i))
@@ -90,7 +85,6 @@ void CGumpSelectFont::GUMP_RADIO_EVENT_C
                 realFont = i;
                 break;
             }
-
             count--;
         }
     }
@@ -106,21 +100,18 @@ void CGumpSelectFont::GUMP_RADIO_EVENT_C
         {
             g_OptionsConfig.ToolTipsTextFont = realFont;
             RemoveMark = true;
-
             break;
         }
         case SFGS_OPT_CHAT:
         {
             g_OptionsConfig.ChatFont = realFont;
             RemoveMark = true;
-
             break;
         }
         case SFGS_OPT_MISCELLANEOUS:
         {
             g_OptionsConfig.SpeechFont = realFont;
             RemoveMark = true;
-
             break;
         }
         default:

--- a/src/Gumps/GumpSelectFont.h
+++ b/src/Gumps/GumpSelectFont.h
@@ -8,15 +8,11 @@
 class CGumpSelectFont : public CGump
 {
 private:
-    static const int ID_GSF_FONTS = 1;
-
-    SELECT_FONT_GUMP_STATE m_State{ SFGS_OPT_POPUP };
+    SELECT_FONT_GUMP_STATE m_State = SFGS_OPT_POPUP;
 
 public:
     CGumpSelectFont(uint32_t serial, short x, short y, SELECT_FONT_GUMP_STATE state);
     virtual ~CGumpSelectFont();
-
     void UpdateContent();
-
     GUMP_RADIO_EVENT_H;
 };

--- a/src/Gumps/GumpStatusbar.cpp
+++ b/src/Gumps/GumpStatusbar.cpp
@@ -83,7 +83,6 @@ static const wstring tooltip[] = {
     L"Change strength state",       //ID_GSB_BUFF_LOCKER_STR
     L"Change dexterity state",      //ID_GSB_BUFF_LOCKER_DEX
     L"Change intelligence state",   //ID_GSB_BUFF_LOCKER_INT
-    L"",                            //
     L"Strength",                    //ID_GSB_TEXT_STR
     L"Dexterity",                   //ID_GSB_TEXT_DEX
     L"Intelligence",                //ID_GSB_TEXT_INT
@@ -92,7 +91,7 @@ static const wstring tooltip[] = {
     L"Hit Points",                  //ID_GSB_TEXT_HITS
     L"Stamina",                     //ID_GSB_TEXT_STAM
     L"Mana",                        //ID_GSB_TEXT_MANA
-    L"Maximum stats",               //ID_GSB_TEXT_MAX_STATS
+    L"Maximum Stats",               //ID_GSB_TEXT_MAX_STATS
     L"Luck",                        //ID_GSB_TEXT_LUCK
     L"Weight",                      //ID_GSB_TEXT_WEIGHT
     L"Damage",                      //ID_GSB_TEXT_DAMAGE
@@ -115,7 +114,7 @@ static const wstring tooltip[] = {
     L"Faster Cast Recovery"         //ID_GSB_TEXT_CAST_RECOVERY
 };
 
-static_assert(countof(tooltip) - 1 == ID_GSB_COUNT, "Wrong amount of entries in tooltip table");
+static_assert(countof(tooltip) == ID_GSB_COUNT, "Wrong amount of entries in tooltip table");
 
 CGumpStatusbar::CGumpStatusbar(uint32_t serial, short x, short y, bool minimized)
     : CGump(GT_STATUSBAR, serial, x, y)
@@ -1049,7 +1048,8 @@ void CGumpStatusbar::UpdateContent()
                 text->CreateTextureA(1, std::to_string(g_Player->MaxWeight), textWidth, TS_CENTER);
 
                 xOffset = useUOPGumps ? 205 : 188;
-                Add(new CGUIHitBox(ID_GSB_TEXT_TITHING_POINTS, xOffset, 70, 65, 24));
+                Add(new CGUIHitBox(ID_GSB_TEXT_MAX_STATS, xOffset, 70, 65, 24));
+                //Add(new CGUIHitBox(ID_GSB_TEXT_TITHING_POINTS, xOffset, 70, 65, 24)); // Find which client version had Tithing Points
                 Add(new CGUIHitBox(ID_GSB_TEXT_LUCK, xOffset, 98, 65, 24));
                 Add(new CGUIHitBox(ID_GSB_TEXT_WEIGHT, xOffset, 126, 65, 24));
 

--- a/src/Managers/ConfigManager.cpp
+++ b/src/Managers/ConfigManager.cpp
@@ -422,7 +422,7 @@ void CConfigManager::DefaultPage3()
     DEBUG_TRACE_FUNCTION;
     UseToolTips = true;
     ToolTipsTextColor = 0xFFFF;
-    ToolTipsTextFont = 0;
+    ToolTipsTextFont = 1;
     ToolTipsDelay = 200;
 }
 

--- a/src/Managers/ConfigManager.h
+++ b/src/Managers/ConfigManager.h
@@ -66,7 +66,7 @@ public:
 
     bool UseToolTips = false;
     uint16_t ToolTipsTextColor = 0;
-    uint16_t ToolTipsTextFont = 0;
+    uint16_t ToolTipsTextFont = 1; // As per client 7.0.47.0
     uint16_t ToolTipsDelay = 0;
 
     uint16_t ChatColorInputText = 0;

--- a/src/Managers/FontsManager.cpp
+++ b/src/Managers/FontsManager.cpp
@@ -1625,94 +1625,91 @@ void CFontsManager::TrimHTMLString(string &str)
     }
 }
 
-uint32_t CFontsManager::GetHTMLColorFromText(string &str)
+uint32_t CFontsManager::GetHTMLColorFromText(string &str1)
 {
     DEBUG_TRACE_FUNCTION;
     uint32_t color = 0;
-
-    if (str.length() > 1)
+    const char *str = str1.data();
+    if (str1.length() > 1)
     {
         if (str[0] == '#')
         {
             char *end;
-            color = strtoul(str.c_str() + 1, &end, 16);
-
+            color = strtoul(str + 1, &end, 16);
             uint8_t *clrBuf = (uint8_t *)&color;
             color = (clrBuf[0] << 24) | (clrBuf[1] << 16) | (clrBuf[2] << 8) | 0xFF;
         }
         else
         {
-            str = ToLowerA(str);
-
-            if (str == "red")
+            if (!SDL_strcasecmp(str, "red"))
             {
                 color = 0x0000FFFF;
             }
-            else if (str == "cyan")
+            else if (!SDL_strcasecmp(str, "cyan"))
             {
                 color = 0xFFFF00FF;
             }
-            else if (str == "blue")
+            else if (!SDL_strcasecmp(str, "blue"))
             {
                 color = 0xFF0000FF;
             }
-            else if (str == "darkblue")
+            else if (!SDL_strcasecmp(str, "darkblue"))
             {
                 color = 0xA00000FF;
             }
-            else if (str == "lightblue")
+            else if (!SDL_strcasecmp(str, "lightblue"))
             {
                 color = 0xE6D8ADFF;
             }
-            else if (str == "purple")
+            else if (!SDL_strcasecmp(str, "purple"))
             {
                 color = 0x800080FF;
             }
-            else if (str == "yellow")
+            else if (!SDL_strcasecmp(str, "yellow"))
             {
                 color = 0x00FFFFFF;
             }
-            else if (str == "lime")
+            else if (!SDL_strcasecmp(str, "lime"))
             {
                 color = 0x00FF00FF;
             }
-            else if (str == "magenta")
+            else if (!SDL_strcasecmp(str, "magenta"))
             {
                 color = 0xFF00FFFF;
             }
-            else if (str == "white")
+            else if (!SDL_strcasecmp(str, "white"))
             {
                 color = 0xFFFEFEFF;
             }
-            else if (str == "silver")
+            else if (!SDL_strcasecmp(str, "silver"))
             {
                 color = 0xC0C0C0FF;
             }
-            else if (str == "gray" || str == "grey")
+            else if (!SDL_strcasecmp(str, "gray") || !SDL_strcasecmp(str, "grey"))
             {
                 color = 0x808080FF;
             }
-            else if (str == "black")
+            else if (!SDL_strcasecmp(str, "black"))
             {
                 color = 0x010101FF;
             }
-            else if (str == "orange")
+            else if (!SDL_strcasecmp(str, "orange"))
             {
                 color = 0x00A5FFFF;
             }
-            else if (str == "brown")
+            else if (!SDL_strcasecmp(str, "brown"))
             {
                 color = 0x2A2AA5FF;
             }
-            else if (str == "maroon")
+            else if (!SDL_strcasecmp(str, "maroon"))
             {
                 color = 0x000080FF;
             }
-            else if (str == "green")
+            else if (!SDL_strcasecmp(str, "green"))
             {
                 color = 0x008000FF;
             }
-            else if (str == "olive")
+            else if (!SDL_strcasecmp(str, "olive"))
             {
                 color = 0x008080FF;
             }
@@ -1884,9 +1881,9 @@ CFontsManager::ParseHTMLTag(const wchar_t *str, int len, int &i, bool &endTag, H
     {
         int cmdLen = i - j;
         //LOG("cmdLen = %i\n", cmdLen);
-        wstring cmd;
-        cmd.resize(cmdLen);
-        memcpy(&cmd[0], &str[j], cmdLen * 2);
+        wstring cmd(&str[j], cmdLen);
+        //cmd.resize(cmdLen);
+        //memcpy(&cmd[0], &str[j], cmdLen * 2);
         //LOG(L"cmd[%s] = %s\n", (endTag ? L"end" : L"start"), cmd.c_str());
         cmd = ToLowerW(cmd);
 
@@ -1995,11 +1992,10 @@ CFontsManager::ParseHTMLTag(const wchar_t *str, int len, int &i, bool &endTag, H
                     case HTT_A:
                     case HTT_DIV:
                     {
-                        wstring content = {};
                         cmdLen = i - j;
                         //LOG("contentCmdLen = %i\n", cmdLen);
-                        content.resize(cmdLen);
-                        memcpy(&content[0], &str[j], cmdLen * 2);
+                        wstring content(&str[j], cmdLen);
+                        //memcpy(&content[0], &str[j], cmdLen * 2);
                         //LOG(L"contentCmd = %s\n", content.c_str());
 
                         if (static_cast<unsigned int>(!content.empty()) != 0u)

--- a/src/ToolTip.cpp
+++ b/src/ToolTip.cpp
@@ -32,22 +32,17 @@ void CToolTip::CreateTextTexture(
 {
     g_FontManager.SetUseHTML(true);
     g_FontManager.RecalculateWidthByInfo = true;
-
     texture.Clear();
-
-    uint8_t font = (uint8_t)g_ConfigManager.ToolTipsTextFont;
-
+    auto font = (uint8_t)g_ConfigManager.ToolTipsTextFont;
     if (width == 0)
     {
         width = g_FontManager.GetWidthW(font, str);
-
         if (width > 600)
         {
             width = 600;
         }
 
         width = g_FontManager.GetWidthExW(font, str, width, TS_CENTER, UOFONT_BLACK_BORDER);
-
         if (width > 600)
         {
             width = 600;
@@ -82,9 +77,7 @@ void CToolTip::Set(const wstring &str, int maxWidth)
     }
 
     Use = !(Timer > g_Ticks);
-
     CRenderObject *object = g_SelectedObject.Object;
-
     if (object == m_Object || object == nullptr)
     { //Уже забиндено или нет объекта для бинда
         return;
@@ -96,7 +89,6 @@ void CToolTip::Set(const wstring &str, int maxWidth)
     Data = str;
     ClilocID = 0;
     MaxWidth = maxWidth;
-
     Position.X = 0;
     Position.Y = 0;
 
@@ -107,7 +99,6 @@ void CToolTip::Set(int clilocID, const string &str, int maxWidth, bool toCamelCa
 {
     DEBUG_TRACE_FUNCTION;
     Set(g_ClilocManager.Cliloc(g_Language)->GetW(clilocID, toCamelCase, str), maxWidth);
-
     ClilocID = clilocID;
 }
 
@@ -128,7 +119,6 @@ void CToolTip::Draw(int cursorWidth, int cursorHeight)
     {
         int x = Position.X;
         int y = Position.Y;
-
         if (x == 0)
         {
             x = g_MouseManager.Position.X - (Texture.Width + 8);
@@ -153,17 +143,11 @@ void CToolTip::Draw(int cursorWidth, int cursorHeight)
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
         glColor4f(0.0f, 0.0f, 0.0f, 0.5f);
-
         g_GL.DrawPolygone(x, y, Texture.Width + 8, Texture.Height + 8);
-
         glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-
         glDisable(GL_BLEND);
-
         g_GL_Draw(Texture, x + 6, y + 4);
     }
-
     Use = false;
 }


### PR DESCRIPTION
Also in this commit:
- Fix tooltip font used to be on parity with original client;
- Fix object properties/text coloring;
- Fix some fonts on options menu to be on parity with original client;

Usual spacing cleanup