### PR TITLE
Reduce packet dumps from info to debug.

### DIFF
--- a/external/loguru.h
+++ b/external/loguru.h
@@ -927,6 +927,8 @@ namespace loguru
 				name = "INFO";
 			} else if (verbosity == Verbosity_1) { // crossuo
 				name = "DEBUG";
+			} else if (verbosity == Verbosity_2) { // crossuo
+				name = "SAFE";
 			} else if (verbosity == Verbosity_9) { // crossuo
 				name = "TRACE";
 			}

--- a/src/CrossUO.cpp
+++ b/src/CrossUO.cpp
@@ -1778,7 +1778,7 @@ int CGame::Send(uint8_t *buf, int size)
         time(&rawtime);
         localtime_s(&timeinfo, &rawtime);
         strftime(buffer, sizeof(buffer), "%d-%m-%Y %H:%M:%S", &timeinfo);
-        Info(
+        DEBUG(
             Network,
             "--- ^(%d) s(+%d => %d) %s Client:: %s",
             ticks - g_LastPacketTime,
@@ -1790,13 +1790,13 @@ int CGame::Send(uint8_t *buf, int size)
 
         if (*buf == 0x80 || *buf == 0x91)
         {
-            INFO_DUMP(Network, "SEND:", buf, 1);
+            DEBUG_DUMP(Network, "SEND:", buf, 1);
             SAFE_DEBUG_DUMP(Network, "SEND:", buf, size);
-            Info(Network, "**** ACCOUNT AND PASSWORD CENSORED ****");
+            DEBUG(Network, "**** ACCOUNT AND PASSWORD CENSORED ****");
         }
         else
         {
-            INFO_DUMP(Network, "SEND:", buf, size);
+            DEBUG_DUMP(Network, "SEND:", buf, size);
         }
     }
 

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -487,7 +487,7 @@ bool CGameWindow::OnUserMessages(const UserEvent &ev)
 
             CPacketInfo &type = g_PacketManager.GetInfo(*buf);
 
-            Info(
+            DEBUG(
                 Plugin,
                 "--- ^(%d) s(+%d => %d) Plugin->Server:: %s",
                 ticks - g_LastPacketTime,
@@ -500,13 +500,13 @@ bool CGameWindow::OnUserMessages(const UserEvent &ev)
 
             if (*buf == 0x80 || *buf == 0x91)
             {
-                INFO_DUMP(Plugin, "SEND:", buf, 1);
+                DEBUG_DUMP(Plugin, "SEND:", buf, 1);
                 SAFE_DEBUG_DUMP(Plugin, "SEND:", buf, size);
-                Info(Plugin, "**** ACCOUNT AND PASSWORD CENSORED ****");
+                DEBUG(Plugin, "**** ACCOUNT AND PASSWORD CENSORED ****");
             }
             else
             {
-                INFO_DUMP(Plugin, "SEND:", buf, size);
+                DEBUG_DUMP(Plugin, "SEND:", buf, size);
             }
             g_ConnectionManager.Send((uint8_t *)ev.data1, checked_cast<int>(ev.data2));
             return true;

--- a/src/Logging.h
+++ b/src/Logging.h
@@ -23,6 +23,7 @@ enum eLogSystem : LogSystem
 #include "Loggers.h"
 #undef LOG_SYSTEM
     LogSystemAll = ~0u,
+    LogSystemNone = 0,
 };
 
 extern eLogSystem g_LogEnabled;
@@ -40,7 +41,7 @@ extern eLogSystem g_LogEnabled;
 
 #define LOG_DUMP_(system, level, ...)                                                              \
     if ((g_LogEnabled & eLogSystem::LogSystem##system) &&                                          \
-        loguru::current_verbosity_cutoff() > level)                                                \
+        ((loguru::Verbosity_##level) <= loguru::current_verbosity_cutoff()))                       \
     LogHexBuffer(eLogSystem::LogSystem##system, int(level), __VA_ARGS__)
 
 #define Info(system, ...) LOG_(system, INFO, __VA_ARGS__)
@@ -55,7 +56,7 @@ extern eLogSystem g_LogEnabled;
 #define DEBUG(system, ...) LOG_(system, 1, __VA_ARGS__)
 #define TRACE_DUMP(system, ...) LOG_DUMP_(system, 9, __VA_ARGS__)
 #define DEBUG_DUMP(system, ...) LOG_DUMP_(system, 1, __VA_ARGS__)
-#define SAFE_DEBUG_DUMP(system, ...) DEBUG_DUMP(system, __VA_ARGS__)
+#define SAFE_DEBUG_DUMP(system, ...) LOG_DUMP_(system, 2, __VA_ARGS__)
 #else
 #define TRACE(...)
 #define DEBUG(...)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -58,6 +58,10 @@ static bool InitCli(int argc, char *argv[])
     g_cli["proxy-port"].type(po::u32).description("Proxy port to use with 'proxy-host'");
     g_cli["proxy-user"].type(po::string).description("Proxy user");
     g_cli["proxy-password"].type(po::string).description("Proxy password");
+    g_cli["quiet"]
+        .abbreviation('q')
+        .description("Disable logging (almost) completely")
+        .callback([&] { g_LogEnabled = eLogSystem::LogSystemNone; });
 
     g_cli(argc, argv);
 

--- a/src/Managers/PacketManager.cpp
+++ b/src/Managers/PacketManager.cpp
@@ -674,7 +674,7 @@ void CPacketManager::OnPacket()
         time(&rawtime);
         localtime_s(&timeinfo, &rawtime);
         strftime(buffer, sizeof(buffer), "%d-%m-%Y %H:%M:%S", &timeinfo);
-        Info(
+        DEBUG(
             Network,
             "--- ^(%d) r(+%zd => %d) %s Server:: %s",
             ticks - g_LastPacketTime,
@@ -683,7 +683,7 @@ void CPacketManager::OnPacket()
             buffer,
             info.Name);
 #else
-        Info(
+        DEBUG(
             Network,
             "--- ^(%d) r(+%zd => %d) Server:: %s",
             ticks - g_LastPacketTime,
@@ -691,7 +691,7 @@ void CPacketManager::OnPacket()
             g_TotalRecvSize,
             info.Name);
 #endif
-        INFO_DUMP(Network, "RECV:", Start, (int)Size);
+        DEBUG_DUMP(Network, "RECV:", Start, (int)Size);
     }
 
     g_LastPacketTime = ticks;
@@ -750,14 +750,14 @@ void CPacketManager::PluginReceiveHandler(uint8_t *buf, int size)
     uint32_t ticks = g_Ticks;
     g_TotalRecvSize += (uint32_t)Size;
     CPacketInfo &info = m_Packets[*Start];
-    Info(
+    DEBUG(
         Network,
         "--- ^(%d) r(+%zd => %d) Plugin->Client:: %s",
         ticks - g_LastPacketTime,
         Size,
         g_TotalRecvSize,
         info.Name);
-    INFO_DUMP(Network, "RECV:", Start, (int)Size);
+    DEBUG_DUMP(Network, "RECV:", Start, (int)Size);
 
     g_LastPacketTime = ticks;
     if (info.Direction != DIR_RECV && info.Direction != DIR_BOTH)

--- a/src/Managers/PluginManager.cpp
+++ b/src/Managers/PluginManager.cpp
@@ -31,7 +31,7 @@ bool CDECL PluginSendFunction(uint8_t *buf, size_t size)
     uint32_t ticks = g_Ticks;
     g_TotalSendSize += checked_cast<int>(size);
     CPacketInfo &type = g_PacketManager.GetInfo(*buf);
-    Info(
+    DEBUG(
         Plugin,
         "--- ^(%d) s(+%zd => %d) Plugin->Server:: %s",
         ticks - g_LastPacketTime,
@@ -43,13 +43,13 @@ bool CDECL PluginSendFunction(uint8_t *buf, size_t size)
     g_LastSendTime = ticks;
     if (*buf == 0x80 || *buf == 0x91)
     {
-        INFO_DUMP(Plugin, "SEND:", buf, 1);
+        DEBUG_DUMP(Plugin, "SEND:", buf, 1);
         SAFE_DEBUG_DUMP(Plugin, "SEND:", buf, int(size));
-        Info(Plugin, "**** ACCOUNT AND PASSWORD CENSORED ****");
+        DEBUG(Plugin, "**** ACCOUNT AND PASSWORD CENSORED ****");
     }
     else
     {
-        INFO_DUMP(Plugin, "SEND:", buf, int(size));
+        DEBUG_DUMP(Plugin, "SEND:", buf, int(size));
     }
 
     g_ConnectionManager.Send(buf, checked_cast<int>(size));


### PR DESCRIPTION
Users when repporting issues will need to send a log generated with
debug level by issuing `-v DEBUG` from command line.