### PR TITLE
Macros conversion

### DIFF
--- a/src/CrossUO.cpp
+++ b/src/CrossUO.cpp
@@ -1486,7 +1486,7 @@ string CGame::FixServerName(string name)
     return name;
 }
 
-void CGame::LoadLocalConfig(int serial)
+void CGame::LoadLocalConfig(int serial, string characterName)
 {
     DEBUG_TRACE_FUNCTION;
     if (g_ConfigLoaded)
@@ -1532,10 +1532,29 @@ void CGame::LoadLocalConfig(int serial)
 
     if (!g_MacroManager.Load(path + ToPath("/macros.cuo"), path + ToPath("/macros.txt")))
     {
-        if (!g_MacroManager.Load(
-                g_App.UOFilesPath("/macros.cuo"), g_App.UOFilesPath("/macros.txt")))
+        char classicClientDesktopSubpathBuf[MAX_PATH] = { 0 };
+        if (server != nullptr)
         {
+            sprintf_s(
+                classicClientDesktopSubpathBuf,
+                "desktop/%s/%s/%s",
+                g_MainScreen.m_Account->c_str(),
+                FixServerName(server->Name).c_str(),
+                characterName.c_str());
         }
+        else
+        {
+            sprintf_s(classicClientDesktopSubpathBuf, "desktop/%s/%s", g_MainScreen.m_Account->c_str(), characterName.c_str());
+        }
+
+		os_path classicClientDesktopSubpath = g_App.UOFilesPath(classicClientDesktopSubpathBuf);
+        if (!g_MacroManager.Load(
+                classicClientDesktopSubpath + ToPath("/macros.cuo"),
+                classicClientDesktopSubpath + ToPath("/macros.txt")))
+        {
+            g_MacroManager.Load(g_App.UOFilesPath("/macros.cuo"), g_App.UOFilesPath("/macros.txt"));
+        }
+
     }
 
     g_GumpManager.Load(path + ToPath("/gumps.cuo"));
@@ -1906,7 +1925,7 @@ void CGame::LoginComplete(bool reload)
         {
             CPacketClientViewRange(g_ConfigManager.UpdateRange).Send();
         }
-        LoadLocalConfig(g_PacketManager.ConfigSerial);
+        LoadLocalConfig(g_PacketManager.ConfigSerial, g_Player->GetName());
     }
 }
 

--- a/src/CrossUO.cpp
+++ b/src/CrossUO.cpp
@@ -1544,17 +1544,20 @@ void CGame::LoadLocalConfig(int serial, string characterName)
         }
         else
         {
-            sprintf_s(classicClientDesktopSubpathBuf, "desktop/%s/%s", g_MainScreen.m_Account->c_str(), characterName.c_str());
+            sprintf_s(
+                classicClientDesktopSubpathBuf,
+                "desktop/%s/%s",
+                g_MainScreen.m_Account->c_str(),
+                characterName.c_str());
         }
 
-		os_path classicClientDesktopSubpath = g_App.UOFilesPath(classicClientDesktopSubpathBuf);
+        os_path classicClientDesktopSubpath = g_App.UOFilesPath(classicClientDesktopSubpathBuf);
         if (!g_MacroManager.Load(
                 classicClientDesktopSubpath + ToPath("/macros.cuo"),
                 classicClientDesktopSubpath + ToPath("/macros.txt")))
         {
             g_MacroManager.Load(g_App.UOFilesPath("/macros.cuo"), g_App.UOFilesPath("/macros.txt"));
         }
-
     }
 
     g_GumpManager.Load(path + ToPath("/gumps.cuo"));

--- a/src/CrossUO.h
+++ b/src/CrossUO.h
@@ -92,7 +92,7 @@ public:
 
     void Process(bool rendering = false);
     void LoadStartupConfig(int serial);
-    void LoadLocalConfig(int serial);
+    void LoadLocalConfig(int serial, string characterName);
     void SaveLocalConfig(int serial);
 
     CIndexObjectLand m_LandDataIndex[MAX_LAND_DATA_INDEX_COUNT];

--- a/src/Managers/MacroManager.cpp
+++ b/src/Managers/MacroManager.cpp
@@ -52,7 +52,7 @@ Keycode CMacroManager::ConvertStringToKeyCode(const vector<string> &strings)
 
     if (str.length() == 1)
     {
-        key = *str.c_str();
+        key = *ToLowerA(str).c_str();
     }
     else if (str.length() != 0u)
     {


### PR DESCRIPTION
This pull request tries to make migration path from classic client easier. It tries to load macros.txt from a subfolder in Desktop and it converts letters to lower case.

Lower case letters are used by CrossUO but classic client uses upper case. When you try to migrate from classic client to CrossUO, you have to fix your macros by pressing a letter for all of your macros to make them work.
