### PR TITLE
Move more data loading stuff to FileManager

### DIFF
--- a/src/CommonInterfaces.cpp
+++ b/src/CommonInterfaces.cpp
@@ -611,7 +611,7 @@ void CDECL FUNCBODY_GetLandArtInfo(unsigned short index, XUO_RAW_ART_INFO &info)
 {
     if (index < MAX_LAND_DATA_INDEX_COUNT)
     {
-        CIndexObjectLand &landData = g_Game.m_LandDataIndex[index];
+        CIndexObjectLand &landData = g_Index.m_Land[index];
 
         if (landData.Address != 0)
         {
@@ -640,7 +640,7 @@ void CDECL FUNCBODY_GetStaticArtInfo(unsigned short index, XUO_RAW_ART_INFO &inf
 {
     if (index < MAX_STATIC_DATA_INDEX_COUNT)
     {
-        CIndexObjectStatic &staticData = g_Game.m_StaticDataIndex[index];
+        CIndexObjectStatic &staticData = g_Index.m_Static[index];
 
         if (staticData.Address != 0)
         {
@@ -669,7 +669,7 @@ void CDECL FUNCBODY_GetGumpArtInfo(unsigned short index, XUO_RAW_GUMP_INFO &info
 {
     if (index < MAX_GUMP_DATA_INDEX_COUNT)
     {
-        CIndexGump &gumpData = g_Game.m_GumpDataIndex[index];
+        CIndexGump &gumpData = g_Index.m_Gump[index];
 
         if (gumpData.Address != 0)
         {

--- a/src/CrossUO.h
+++ b/src/CrossUO.h
@@ -17,54 +17,32 @@ public:
     string m_OverrideServerAddress;
     int m_OverrideServerPort = 0;
 
+    uint16_t m_WinterTile[MAX_LAND_DATA_INDEX_COUNT];
+    std::vector<std::pair<uint16_t, uint16_t>> m_IgnoreInFilterTiles;
+    std::deque<CIndexObjectStatic *> m_StaticAnimList;
+    std::deque<CIndexObject *> m_UsedLandList;
+    std::deque<CIndexObject *> m_UsedStaticList;
+    std::deque<CIndexObject *> m_UsedGumpList;
+    std::deque<CIndexObject *> m_UsedTextureList;
+    std::deque<CIndexObject *> m_UsedLightList;
+    std::deque<CIndexSound *> m_UsedSoundList;
+
 private:
-    uint32_t m_CRC_Table[256];
-
-    uint8_t m_StaticTilesFilterFlags[0x10000];
-
-    vector<uint16_t> m_StumpTiles;
-    vector<uint16_t> m_CaveTiles;
-
-    deque<CIndexObjectStatic *> m_StaticAnimList;
-
-    deque<CIndexObject *> m_UsedLandList;
-    deque<CIndexObject *> m_UsedStaticList;
-    deque<CIndexObject *> m_UsedGumpList;
-    deque<CIndexObject *> m_UsedTextureList;
-    deque<CIndexSound *> m_UsedSoundList;
-    deque<CIndexObject *> m_UsedLightList;
-
-    vector<uint8_t> m_AnimData;
-
+    uint8_t m_StaticTilesFilterFlags[MAX_STATIC_DATA_INDEX_COUNT];
     string m_GameServerIP = "";
 
     void LoadAutoLoginNames();
-    void LoadIndexFiles();
-    void UnloadIndexFiles();
-    void InitStaticAnimList();
-    uint16_t CalculateLightColor(uint16_t id);
     void ProcessStaticAnimList();
     void PatchFiles();
     void IndexReplaces();
+    void InitStaticAnimList();
     void LoadClientStartupConfig();
     void LoadShaders();
     void CreateAuraTexture();
     void CreateObjectHandlesBackground();
     void ClearUnusedTextures();
-    void MulReadIndexFile(
-        size_t indexMaxCount,
-        const std::function<CIndexObject *(int index)> &getIdxObj,
-        size_t address,
-        IndexBlock *ptr,
-        const std::function<IndexBlock *()> &getNewPtrValue);
-    void UopReadIndexFile(
-        size_t indexMaxCount,
-        const std::function<CIndexObject *(int index)> &getIdxObj,
-        const char *uopFileName,
-        int padding,
-        const char *extesion,
-        CUopMappedFile &uopFile,
-        int startIndex = 0);
+    void UnloadIndexFiles();
+
     uint16_t TextToGraphic(const char *text);
     void CheckStaticTileFilterFiles();
     string DecodeArgumentString(const char *text, int length);
@@ -75,11 +53,6 @@ private:
 public:
     CGame();
     ~CGame();
-
-    static uint64_t CreateHash(const char *s);
-
-    vector<MulLandTile2> m_LandData;
-    vector<MulStaticTile2> m_StaticData;
 
     bool Install();
     void Uninstall();
@@ -93,19 +66,6 @@ public:
     void LoadStartupConfig(int serial);
     void LoadLocalConfig(int serial, string characterName);
     void SaveLocalConfig(int serial);
-
-    CIndexObjectLand m_LandDataIndex[MAX_LAND_DATA_INDEX_COUNT];
-    CIndexObjectStatic m_StaticDataIndex[MAX_STATIC_DATA_INDEX_COUNT];
-    CIndexGump m_GumpDataIndex[MAX_GUMP_DATA_INDEX_COUNT];
-    CIndexObject m_TextureDataIndex[MAX_LAND_TEXTURES_DATA_INDEX_COUNT];
-    CIndexSound m_SoundDataIndex[MAX_SOUND_DATA_INDEX_COUNT];
-    CIndexMusic m_MP3Data[MAX_MUSIC_DATA_INDEX_COUNT];
-    CIndexMulti m_MultiDataIndex[MAX_MULTI_DATA_INDEX_COUNT];
-    CIndexLight m_LightDataIndex[MAX_LIGHTS_DATA_INDEX_COUNT];
-
-    uint16_t m_WinterTile[MAX_LAND_DATA_INDEX_COUNT];
-
-    vector<std::pair<uint16_t, uint16_t>> m_IgnoreInFilterTiles;
 
     bool InTileFilter(uint16_t graphic);
 
@@ -140,7 +100,7 @@ public:
     bool IsVegetation(uint16_t graphic);
     uint64_t GetLandFlags(uint16_t id);
     uint64_t GetStaticFlags(uint16_t id);
-    uint16_t GetLightColor(uint16_t id) { return m_StaticDataIndex[id].LightColor; }
+    uint16_t GetLightColor(uint16_t id) { return g_Index.m_Static[id].LightColor; }
     CSize GetStaticArtDimension(uint16_t id);
     CSize GetGumpDimension(uint16_t id);
     CGLTexture *ExecuteGump(uint16_t id);
@@ -213,7 +173,6 @@ public:
     void OpenDoor();
     void EmoteAction(const char *action);
     void AllNames();
-    uint32_t GetFileHashCode(uint8_t *ptr, size_t size);
     void LoadLogin(string &login, int &port);
     void GoToWebLink(const string &url);
     void RemoveRangedObjects();

--- a/src/GUI/GUITilepic.cpp
+++ b/src/GUI/GUITilepic.cpp
@@ -54,7 +54,7 @@ bool CGUITilepic::Select()
     DEBUG_TRACE_FUNCTION;
     //if (CGUIDrawObject::Select())
     //	return true;
-    CGLTexture *th = g_Game.m_StaticDataIndex[Graphic].Texture;
+    CGLTexture *th = g_Index.m_Static[Graphic].Texture;
 
     if (th != nullptr)
     {

--- a/src/GUI/GUITilepicHightlighted.cpp
+++ b/src/GUI/GUITilepicHightlighted.cpp
@@ -77,7 +77,7 @@ void CGUITilepicHightlighted::Draw(bool checktrans)
 bool CGUITilepicHightlighted::Select()
 {
     DEBUG_TRACE_FUNCTION;
-    CGLTexture *th = g_Game.m_StaticDataIndex[Graphic].Texture;
+    CGLTexture *th = g_Index.m_Static[Graphic].Texture;
 
     if (th != nullptr)
     {

--- a/src/GameObjects/GameItem.cpp
+++ b/src/GameObjects/GameItem.cpp
@@ -71,7 +71,7 @@ void CGameItem::OnGraphicChange(int direction)
     DEBUG_TRACE_FUNCTION;
     if (!MultiBody)
     {
-        if (Graphic >= g_Game.m_StaticData.size())
+        if (Graphic >= g_Data.m_Static.size())
         {
             return;
         }
@@ -92,7 +92,7 @@ void CGameItem::OnGraphicChange(int direction)
         }
         else
         {
-            m_TiledataPtr = &g_Game.m_StaticData[Graphic];
+            m_TiledataPtr = &g_Data.m_Static[Graphic];
             MulStaticTile2 &tile = *m_TiledataPtr;
             NoDrawTile = IsNoDrawTile(Graphic);
             if (IsWearable() || Graphic == 0x0A28)
@@ -682,7 +682,7 @@ void CGameItem::LoadMulti(bool dropAlpha)
 
     WantUpdateMulti = false;
 
-    CIndexMulti &index = g_Game.m_MultiDataIndex[Graphic];
+    CIndexMulti &index = g_Index.m_Multi[Graphic];
 
     size_t address = index.Address;
     int count = index.Count;

--- a/src/GameObjects/GameObject.cpp
+++ b/src/GameObjects/GameObject.cpp
@@ -104,7 +104,7 @@ void CGameObject::DrawObjectHandlesTexture()
             if (name.length() == 0u)
             {
                 name = g_ClilocManager.Cliloc(g_Language)
-                           ->GetW(1020000 + Graphic, true, g_Game.m_StaticData[Graphic].Name);
+                           ->GetW(1020000 + Graphic, true, g_Data.m_Static[Graphic].Name);
             }
             GenerateObjectHandlesTexture(name);
         }

--- a/src/GameObjects/GamePlayer.cpp
+++ b/src/GameObjects/GamePlayer.cpp
@@ -79,7 +79,7 @@ void CPlayer::UpdateAbilities()
 
         uint16_t testGraphic = equippedGraphic - 1;
 
-        if (g_Game.m_StaticData[testGraphic].AnimID == imageID)
+        if (g_Data.m_Static[testGraphic].AnimID == imageID)
         {
             graphics[1] = testGraphic;
             count = 2;
@@ -88,7 +88,7 @@ void CPlayer::UpdateAbilities()
         {
             testGraphic = equippedGraphic + 1;
 
-            if (g_Game.m_StaticData[testGraphic].AnimID == imageID)
+            if (g_Data.m_Static[testGraphic].AnimID == imageID)
             {
                 graphics[1] = testGraphic;
                 count = 2;

--- a/src/GameObjects/LandObject.cpp
+++ b/src/GameObjects/LandObject.cpp
@@ -16,7 +16,7 @@ CLandObject::CLandObject(int serial, uint16_t graphic, uint16_t color, short x, 
 
     m_DrawTextureColor[3] = 0xFF;
 
-    MulLandTile2 &tile = g_Game.m_LandData[graphic];
+    MulLandTile2 &tile = g_Data.m_Land[graphic];
     IsStretched = ((tile.TexID == 0u) && ::IsWet(tile.Flags));
 
     memset(&m_Rect, 0, sizeof(m_Rect));

--- a/src/GameObjects/RenderStaticObject.cpp
+++ b/src/GameObjects/RenderStaticObject.cpp
@@ -22,7 +22,7 @@ CRenderStaticObject::CRenderStaticObject(
     : CMapObject(renderType, serial, graphic, color, x, y, z)
 {
     DEBUG_TRACE_FUNCTION;
-    m_TiledataPtr = &g_Game.m_StaticData[graphic];
+    m_TiledataPtr = &g_Data.m_Static[graphic];
 
     if (m_TiledataPtr->Height > 5)
     {

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -57,8 +57,6 @@ CSize g_MapSize[MAX_MAPS_COUNT] = {
 };
 CSize g_MapBlockSize[MAX_MAPS_COUNT];
 
-int g_MultiIndexCount = 0;
-
 CGLFrameBuffer g_LightBuffer;
 
 bool g_GumpPressed = false;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -83,8 +83,6 @@ extern CGLTexture g_TextureGumpState[2];
 extern CSize g_MapSize[MAX_MAPS_COUNT];
 extern CSize g_MapBlockSize[MAX_MAPS_COUNT];
 
-extern int g_MultiIndexCount;
-
 extern class CGLFrameBuffer g_LightBuffer;
 
 extern bool g_GumpPressed;

--- a/src/Gumps/GumpCombatBook.cpp
+++ b/src/Gumps/GumpCombatBook.cpp
@@ -510,7 +510,7 @@ void CGumpCombatBook::UpdateContent()
         vector<uint16_t> list = GetItemsList((uint8_t)i);
 
         int size = (int)list.size();
-        size_t maxStaticCount = g_Game.m_StaticData.size();
+        size_t maxStaticCount = g_Data.m_Static.size();
 
         int textX = 62;
         int textY = 98;
@@ -531,7 +531,7 @@ void CGumpCombatBook::UpdateContent()
             }
 
             CGUIText *text = (CGUIText *)Add(new CGUIText(0x0288, textX, textY));
-            text->CreateTextureA(9, ToCamelCase(g_Game.m_StaticData[id].Name));
+            text->CreateTextureA(9, ToCamelCase(g_Data.m_Static[id].Name));
 
             textY += 16;
         }

--- a/src/Gumps/GumpMinimap.cpp
+++ b/src/Gumps/GumpMinimap.cpp
@@ -109,7 +109,7 @@ void CGumpMinimap::GenerateMap()
     m_Texture.Clear();
 
     uint16_t gumpID = 0x1393 - (int)Minimized;
-    CIndexObject &io = g_Game.m_GumpDataIndex[gumpID];
+    CIndexObject &io = g_Index.m_Gump[gumpID];
 
     int gumpWidth = io.Width;
     int gumpHeight = io.Height;

--- a/src/Gumps/GumpPaperdoll.cpp
+++ b/src/Gumps/GumpPaperdoll.cpp
@@ -636,7 +636,7 @@ void CGumpPaperdoll::UpdateContent()
                 {
                     uint32_t slotSerial = ID_GP_ITEMS + equipment->Layer;
 
-                    CIndexObjectStatic &sio = g_Game.m_StaticDataIndex[equipment->Graphic];
+                    CIndexObjectStatic &sio = g_Index.m_Static[equipment->Graphic];
                     CGLTexture *texture = sio.Texture;
 
                     if (texture == nullptr)

--- a/src/Gumps/GumpStatusbar.cpp
+++ b/src/Gumps/GumpStatusbar.cpp
@@ -565,7 +565,7 @@ void CGumpStatusbar::UpdateContent()
                 gumpId = 0x0802;
             }
             Add(new CGUIGumppic(gumpId, 0, 0));
-            auto &io = g_Game.m_GumpDataIndex[gumpId];
+            auto &io = g_Index.m_Gump[gumpId];
             int xOffset = 0;
 
             if (io.DataSize == 169884 && io.Height == 171 && io.Width == 409)

--- a/src/Gumps/GumpWorldMap.cpp
+++ b/src/Gumps/GumpWorldMap.cpp
@@ -314,19 +314,17 @@ void CGumpWorldMap::LoadMap(int map)
 
         if (g_FileManager.m_MapUOP[map].Start == nullptr)
         {
-            crc32 = g_Game.GetFileHashCode(
-                g_FileManager.m_MapMul[map].Start, g_FileManager.m_MapMul[map].Size);
+            crc32 = Checksum32(g_FileManager.m_MapMul[map].Start, g_FileManager.m_MapMul[map].Size);
         }
         else
         {
-            crc32 = g_Game.GetFileHashCode(
-                g_FileManager.m_MapUOP[map].Start, g_FileManager.m_MapUOP[map].Size);
+            crc32 = Checksum32(g_FileManager.m_MapUOP[map].Start, g_FileManager.m_MapUOP[map].Size);
         }
 
-        crc32 ^= g_Game.GetFileHashCode(
-            g_FileManager.m_StaticIdx[map].Start, g_FileManager.m_StaticIdx[map].Size);
-        crc32 ^= g_Game.GetFileHashCode(
-            g_FileManager.m_StaticMul[map].Start, g_FileManager.m_StaticMul[map].Size);
+        crc32 ^=
+            Checksum32(g_FileManager.m_StaticIdx[map].Start, g_FileManager.m_StaticIdx[map].Size);
+        crc32 ^=
+            Checksum32(g_FileManager.m_StaticMul[map].Start, g_FileManager.m_StaticMul[map].Size);
 
         if (g_FileManager.m_MapMul[map].Start != nullptr)
         {
@@ -334,17 +332,17 @@ void CGumpWorldMap::LoadMap(int map)
             {
                 if (g_MapManager.m_MapPatchCount[i] != 0)
                 {
-                    crc32 ^= g_Game.GetFileHashCode(
+                    crc32 ^= Checksum32(
                         g_FileManager.m_MapDifl[i].Start, g_FileManager.m_MapDifl[i].Size);
-                    crc32 ^= g_Game.GetFileHashCode(
-                        g_FileManager.m_MapDif[i].Start, g_FileManager.m_MapDif[i].Size);
+                    crc32 ^=
+                        Checksum32(g_FileManager.m_MapDif[i].Start, g_FileManager.m_MapDif[i].Size);
                 }
 
                 if (g_MapManager.m_StaticPatchCount[i] != 0)
                 {
-                    crc32 ^= g_Game.GetFileHashCode(
+                    crc32 ^= Checksum32(
                         g_FileManager.m_StaDifl[i].Start, g_FileManager.m_StaDifl[i].Size);
-                    crc32 ^= g_Game.GetFileHashCode(
+                    crc32 ^= Checksum32(
                         g_FileManager.m_StaDifi[i].Start, g_FileManager.m_StaDifi[i].Size);
                 }
             }

--- a/src/IndexObject.cpp
+++ b/src/IndexObject.cpp
@@ -4,6 +4,8 @@
 #include "IndexObject.h"
 #include "Config.h"
 
+Index g_Index;
+
 // FIXME: Texture should be managed elsewhere
 CIndexObject::~CIndexObject()
 {

--- a/src/IndexObject.h
+++ b/src/IndexObject.h
@@ -98,3 +98,19 @@ struct CIndexMusic
     string FilePath;
     bool Loop = false;
 };
+
+struct Index
+{
+    CIndexObjectLand m_Land[MAX_LAND_DATA_INDEX_COUNT];
+    CIndexObjectStatic m_Static[MAX_STATIC_DATA_INDEX_COUNT];
+    CIndexGump m_Gump[MAX_GUMP_DATA_INDEX_COUNT];
+    CIndexObject m_Texture[MAX_LAND_TEXTURES_DATA_INDEX_COUNT];
+    CIndexSound m_Sound[MAX_SOUND_DATA_INDEX_COUNT];
+    CIndexMusic m_MP3[MAX_MUSIC_DATA_INDEX_COUNT];
+    CIndexMulti m_Multi[MAX_MULTI_DATA_INDEX_COUNT];
+    CIndexLight m_Light[MAX_LIGHTS_DATA_INDEX_COUNT];
+
+    int m_MultiIndexCount = 0;
+};
+
+extern Index g_Index;

--- a/src/Managers/FileManager.h
+++ b/src/Managers/FileManager.h
@@ -3,12 +3,24 @@
 
 #pragma once
 
+#include "../IndexObject.h"
 #include "../FileSystem.h"
 #include "../Wisp/WispMappedFile.h"
 #include "../Utility/AutoResetEvent.h"
 
 struct CTextureAnimationDirection;
 using UopBlockHeaderMap = std::unordered_map<uint64_t, const UopBlockHeader *>;
+
+struct Data
+{
+    std::vector<MulLandTile2> m_Land;
+    std::vector<MulStaticTile2> m_Static;
+    std::vector<uint16_t> m_StumpTiles;
+    std::vector<uint16_t> m_CaveTiles;
+    std::vector<uint8_t> m_Anim;
+};
+
+extern Data g_Data;
 
 struct CUopMappedFile : public Wisp::CMappedFile
 {
@@ -93,16 +105,38 @@ struct CFileManager : public Wisp::CDataReader
     bool IsMulFileOpen(int idx) const;
     static bool UopDecompressBlock(const UopBlockHeader &block, uint8_t *dst, int fileId);
 
-    void LoadTiledata(vector<MulLandTile2> &landData, vector<MulStaticTile2> &staticsData);
+    void LoadData();
 
     CFileManager() = default;
     virtual ~CFileManager() = default;
 
 private:
+    void LoadTiledata();
+    void LoadIndexFiles();
+
     void ReadTask();
     bool UopLoadFile(CUopMappedFile &file, const char *fileName);
     bool MulLoadFile(Wisp::CMappedFile &file, const os_path &fileName);
     void ProcessAnimSequeceData();
+
+    void MulReadIndexFile(
+        size_t indexMaxCount,
+        const std::function<CIndexObject *(int index)> &getIdxObj,
+        size_t address,
+        IndexBlock *ptr,
+        const std::function<IndexBlock *()> &getNewPtrValue);
+    void UopReadIndexFile(
+        size_t indexMaxCount,
+        const std::function<CIndexObject *(int index)> &getIdxObj,
+        const char *uopFileName,
+        int padding,
+        const char *extesion,
+        CUopMappedFile &uopFile,
+        int startIndex = 0);
 };
+
+uint64_t CreateAssetHash(const char *s);
+void InitChecksum32();
+uint32_t Checksum32(uint8_t *ptr, size_t size);
 
 extern CFileManager g_FileManager;

--- a/src/Managers/FontsManager.cpp
+++ b/src/Managers/FontsManager.cpp
@@ -29,33 +29,26 @@ bool CFontsManager::LoadFonts()
     DEBUG_TRACE_FUNCTION;
 
     Wisp::CMappedFile fontFile;
-
     if (!fontFile.Load(g_App.UOFilesPath("fonts.mul")))
     {
         return false;
     }
 
     FontCount = 0;
-
     while (!fontFile.IsEOF())
     {
         bool exit = false;
         fontFile.Move(1);
-
         for (int i = 0; i < 224; i++)
         {
             FONT_HEADER *fh = (FONT_HEADER *)fontFile.Ptr;
             fontFile.Move(sizeof(FONT_HEADER));
-
             int bcount = fh->Width * fh->Height * 2;
-
             if (fontFile.Ptr + bcount > fontFile.End) //Bad font file...
             {
                 exit = true;
-
                 break;
             }
-
             fontFile.Move(bcount);
         }
 
@@ -63,7 +56,6 @@ bool CFontsManager::LoadFonts()
         {
             break;
         }
-
         FontCount++;
     }
 
@@ -71,19 +63,15 @@ bool CFontsManager::LoadFonts()
     {
         Font = nullptr;
         FontCount = 0;
-
         return false;
     }
 
     Font = new FONT_DATA[FontCount];
-
     fontFile.ResetPtr();
-
     for (int i = 0; i < FontCount; i++)
     {
         FONT_DATA &fd = Font[i];
         fd.Header = fontFile.ReadUInt8();
-
         for (int j = 0; j < 224; j++)
         {
             FONT_CHARACTER_DATA &fcd = fd.Chars[j];
@@ -116,7 +104,6 @@ bool CFontsManager::LoadFonts()
             m_FontIndex[i] = m_FontIndex[' '];
         }
     }
-
     return true;
 }
 

--- a/src/Managers/MapManager.cpp
+++ b/src/Managers/MapManager.cpp
@@ -106,7 +106,7 @@ void CMapManager::CreateBlockTable(int map)
                     "build/map%dlegacymul/%08d.dat",
                     map,
                     shifted);
-                auto block = uopFile.GetBlock(CGame::CreateHash(mapFilePath));
+                auto block = uopFile.GetBlock(CreateAssetHash(mapFilePath));
                 if (block != nullptr)
                 {
                     uopOffset = size_t(block->Offset + block->HeaderSize);

--- a/src/ScreenStages/GameScreen.cpp
+++ b/src/ScreenStages/GameScreen.cpp
@@ -2368,9 +2368,8 @@ void CGameScreen::OnLeftMouseButtonUp()
                         if (td == nullptr || td->Timer < g_Ticks)
                         {
                             uint16_t id = rwo->Graphic;
-                            wstring str =
-                                g_ClilocManager.Cliloc(g_Language)
-                                    ->GetW(1020000 + id, true, g_Game.m_StaticData[id].Name);
+                            wstring str = g_ClilocManager.Cliloc(g_Language)
+                                              ->GetW(1020000 + id, true, g_Data.m_Static[id].Name);
                             if (str.length() != 0u)
                             {
                                 // const uint8_t font = g_ConfigManager.ToolTipsTextFont; ?

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -348,7 +348,7 @@ void CTarget::LoadMulti(int offsetX, int offsetY, char offsetZ)
     DEBUG_TRACE_FUNCTION;
     UnloadMulti();
 
-    CIndexMulti &index = g_Game.m_MultiDataIndex[MultiGraphic - 1];
+    CIndexMulti &index = g_Index.m_Multi[MultiGraphic - 1];
     int count = (int)index.Count;
     if (index.UopBlock != nullptr)
     {

--- a/src/TargetGump.cpp
+++ b/src/TargetGump.cpp
@@ -44,7 +44,7 @@ void CNewTargetSystem::Draw()
     DEBUG_TRACE_FUNCTION;
     if (!g_ConfigManager.DisableNewTargetSystem && ColorGump != 0)
     {
-        CIndexObject &top = g_Game.m_GumpDataIndex[GumpTop];
+        CIndexObject &top = g_Index.m_Gump[GumpTop];
 
         int x = X - (top.Width / 2);
 


### PR DESCRIPTION
The idea here is to centralize the most possible from simple data
loading in one module so we can share with other tools (assit or
anything else) and to easy modifying further, but also reducing
cruft on main game module.

Basically this creates two new global structures g_Data and g_Index that
hold data and index stuff respectively.
Things like m_StaticData became g_Data.m_Static, and m_StaticDataIndex
became g_Index.m_Static.