### PR TITLE
Fix crash introduced in dd3a1c69

### DIFF
--- a/src/Gumps/GumpPaperdoll.cpp
+++ b/src/Gumps/GumpPaperdoll.cpp
@@ -656,7 +656,7 @@ void CGumpPaperdoll::UpdateContent()
                             }
                         }
 
-                        auto spr = new CSprite();
+                        spr = new CSprite();
                         spr->LoadSprite16(wantImageWidth, wantImageHeight, wantPixels.data());
                         if (wantImageWidth < 14)
                         {
@@ -686,7 +686,7 @@ void CGumpPaperdoll::UpdateContent()
 
                         auto ext = new CGUIExternalTexture(
                             spr, true, tileX, tileY, wantImageWidth, wantImageHeight);
-                        m_DataBox->Add(obj);
+                        m_DataBox->Add(ext);
                         ext->DrawOnly = true;
                         ext->Color = equipment->Color & 0x3FFF;
                     }


### PR DESCRIPTION
Variable shadowing and type confusion, this means we must cleanup all
warnings so we can enable most of them to help catch these.