### PR TITLE
CrossUO installer/updater reimplementation (first pass)

### DIFF
--- a/common/fs.h
+++ b/common/fs.h
@@ -156,7 +156,8 @@ FS_PRIVATE fs_path const &fs_path_from(fs_path const &p)
 #if defined(_MSC_VER)
 
 #include <Windows.h>
-#include <Shlwapi.h>
+#include <shlwapi.h>
+#include <shlobj.h>
 #include <assert.h>
 #include <algorithm>
 #pragma comment(lib, "Shlwapi.lib")

--- a/tools/xuoi/CMakeLists.txt
+++ b/tools/xuoi/CMakeLists.txt
@@ -23,6 +23,8 @@ set(XUOI_INCLUDE "${XUOI_DIR}" CACHE INTERNAL "")
 set(XUOI_LIBS "${PROJECT_NAME} ${THREAD} ${LOADER}" CACHE INTERNAL "")
 
 set(XUOI_SRCS
+  http.cpp
+  xuo_updater.cpp
   main.cpp
 )
 

--- a/tools/xuoi/http.cpp
+++ b/tools/xuoi/http.cpp
@@ -1,3 +1,6 @@
+// MIT License
+// Copyright (c) 2019 Danny Angelo Carminati Grein
+
 #include "http.h"
 
 #include <vector>

--- a/tools/xuoi/http.cpp
+++ b/tools/xuoi/http.cpp
@@ -1,0 +1,149 @@
+#include "http.h"
+
+#include <vector>
+#include <string>
+#include <string.h>
+#include <assert.h>
+
+#define CURL_STATICLIB
+#include <curl/curl.h>
+#include <external/tinyxml2.h> // not really needed here, just for the version info
+
+#define LOG_DEBUG(...) // comment to enable debug logging
+#define LOG_TRACE(...) // comment to enable tracing
+#include <common/fs.h>
+#include <common/log.h>
+
+static const char *s_agentName = nullptr;
+
+#define DO_CURL(x)                                                                                 \
+    do                                                                                             \
+    {                                                                                              \
+        CURLcode r = curl_easy_##x;                                                                \
+        if (r != CURLE_OK)                                                                         \
+            LOG_ERROR(__FILE__ ":%d:ERROR:%d: %s\n", __LINE__, r, curl_easy_strerror(r));          \
+    } while (0)
+
+static size_t recv_data_string(const char *data, size_t size, size_t nmemb, std::string *str)
+{
+    assert(data && str && size && nmemb);
+    const auto amount = size * nmemb;
+    str->append(data, amount);
+    return amount;
+}
+
+static size_t recv_data_vector(const char *data, size_t size, size_t nmemb, std::vector<char> *vec)
+{
+    assert(data && vec && size && nmemb);
+    const auto amount = size * nmemb;
+    vec->insert(vec->end(), data, data + amount);
+    return amount;
+}
+
+struct http_recv_buf
+{
+    size_t max_len;
+    size_t offset;
+    const uint8_t *data;
+};
+static size_t recv_data(const char *data, size_t size, size_t nmemb, http_recv_buf *buf)
+{
+    assert(data && buf && size && nmemb);
+    const auto amount = size * nmemb;
+    assert(buf->offset + amount < buf->max_len);
+    memcpy((void *)&buf->data[buf->offset], data, amount);
+    buf->offset += amount;
+    return amount;
+}
+
+static CURL *s_curl_handle = nullptr;
+void http_init()
+{
+    if (s_curl_handle)
+        return;
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl_version_info_data *info = curl_version_info(CURLVERSION_NOW);
+    LOG_INFO(
+        "libcurl %s (%s, %s, %s, libz/%s, tinyxml2/%d.%d.%d)\n",
+        info->version,
+        info->host,
+        info->ssl_version,
+        info->libssh_version,
+        info->libz_version,
+        TINYXML2_MAJOR_VERSION,
+        TINYXML2_MINOR_VERSION,
+        TINYXML2_PATCH_VERSION);
+    s_curl_handle = curl_easy_init();
+}
+
+void http_set_user_agent(const char *name)
+{
+    s_agentName = name;
+}
+
+void http_shutdown()
+{
+    curl_easy_cleanup(s_curl_handle);
+    s_curl_handle = nullptr;
+    curl_global_cleanup();
+}
+
+void http_get_binary(const char *url, const uint8_t *buf, size_t *size)
+{
+    assert(buf && size);
+    http_recv_buf tmp = { *size, 0, buf };
+    LOG_TRACE("url %s\n", url);
+    CURL *curl = curl_easy_duphandle(s_curl_handle);
+    if (s_agentName)
+        DO_CURL(setopt(curl, CURLOPT_USERAGENT, s_agentName));
+    DO_CURL(setopt(curl, CURLOPT_URL, url));
+    DO_CURL(setopt(curl, CURLOPT_WRITEDATA, &tmp));
+    DO_CURL(setopt(curl, CURLOPT_WRITEFUNCTION, recv_data));
+    DO_CURL(perform(curl));
+    curl_easy_cleanup(curl);
+    *size = tmp.offset;
+}
+
+void http_get_binary(const char *url, std::vector<uint8_t> &data)
+{
+    LOG_TRACE("url %s\n", url);
+    CURL *curl = curl_easy_duphandle(s_curl_handle);
+    if (s_agentName)
+        DO_CURL(setopt(curl, CURLOPT_USERAGENT, s_agentName));
+    DO_CURL(setopt(curl, CURLOPT_URL, url));
+    DO_CURL(setopt(curl, CURLOPT_WRITEDATA, &data));
+    DO_CURL(setopt(curl, CURLOPT_WRITEFUNCTION, recv_data_vector));
+    DO_CURL(perform(curl));
+    curl_easy_cleanup(curl);
+}
+
+void http_get_string(const char *url, std::string &data)
+{
+    LOG_TRACE("url %s\n", url);
+    CURL *curl = curl_easy_duphandle(s_curl_handle);
+    if (s_agentName)
+        DO_CURL(setopt(curl, CURLOPT_USERAGENT, s_agentName));
+    DO_CURL(setopt(curl, CURLOPT_URL, url));
+    DO_CURL(setopt(curl, CURLOPT_WRITEDATA, &data));
+    DO_CURL(setopt(curl, CURLOPT_WRITEFUNCTION, recv_data_string));
+    DO_CURL(perform(curl));
+    curl_easy_cleanup(curl);
+}
+
+bool http_get_file(const char *url, const char *filename)
+{
+    FILE *fp = fopen(filename, "wb");
+    if (!fp)
+        return false;
+
+    LOG_TRACE("url %s\n", url);
+    CURL *curl = curl_easy_duphandle(s_curl_handle);
+    if (s_agentName)
+        DO_CURL(setopt(curl, CURLOPT_USERAGENT, s_agentName));
+    DO_CURL(setopt(curl, CURLOPT_URL, url));
+    DO_CURL(setopt(curl, CURLOPT_WRITEDATA, fp));
+    DO_CURL(perform(curl));
+    curl_easy_cleanup(curl);
+    fclose(fp);
+    return true;
+}

--- a/tools/xuoi/http.h
+++ b/tools/xuoi/http.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+void http_init();
+void http_shutdown();
+void http_set_user_agent(const char *name);
+void http_get_binary(const char *url, const uint8_t *buf, size_t *size);
+void http_get_binary(const char *url, std::vector<uint8_t> &data);
+void http_get_string(const char *url, std::string &data);
+bool http_get_file(const char *url, const char *filename);

--- a/tools/xuoi/http.h
+++ b/tools/xuoi/http.h
@@ -1,3 +1,6 @@
+// MIT License
+// Copyright (c) 2019 Danny Angelo Carminati Grein
+
 #pragma once
 
 #include <stdint.h>

--- a/tools/xuoi/main.cpp
+++ b/tools/xuoi/main.cpp
@@ -1,7 +1,6 @@
 // GPLv3 License
 // Copyright (c) 2019 Danny Angelo Carminati Grein
 
-//#include <gperftools/profiler.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -582,7 +581,7 @@ void mft_listing_save(mft_product &prod)
     {
         fprintf(
             fp,
-            "%s,0,0,%lu,0,0,0,0,0,%s,%s\n",
+            "%s,0,0,%" PRIu64 ",0,0,0,0,0,%s,%s\n",
             prod.launchfile,
             prod.timestamp,
             prod.file_repo,
@@ -601,7 +600,7 @@ void mft_listing_save(mft_product &prod)
             hashlittle2(tmp, len, &ph, &sh);
             fprintf(
                 fp,
-                "%s,%08x,%08x,%lu,%08x,%zu,%zu,0,0\n",
+                "%s,%08x,%08x,%" PRIu64 ",%08x,%zu,%zu,0,0\n",
                 e.name,
                 ph,
                 sh,
@@ -617,7 +616,7 @@ void mft_listing_save(mft_product &prod)
 
             fprintf(
                 fp,
-                "%s/%08x%08x,%08x,%08x,%lu,%08x,%zu,%zu,%08x,%u\n",
+                "%s/%08x%08x,%08x,%08x,%" PRIu64 ",%08x,%zu,%zu,%08x,%u\n",
                 e.pack_name,
                 e.ph,
                 e.sh,
@@ -658,7 +657,7 @@ void mft_listing_load_latest_version(mft_product &prod)
         mft_entry e;
         fscanf(
             fp,
-            "%512[^,],%08x,%08x,%lu,%08x,%zu,%zu,%08x,%u%c%n",
+            "%512[^,],%08x,%08x,%" PRIu64 ",%08x,%zu,%zu,%08x,%u%c%n",
             tmp,
             &e.ph,
             &e.sh,
@@ -677,7 +676,7 @@ void mft_listing_load_latest_version(mft_product &prod)
 
         count++;
         prod.base_version[n] = e;
-        //fprintf(stdout, "%s,%08x,%08x,%lu,%08x,%zu,%zu\n", n.c_str(), e.ph, e.sh, e.timestamp, e.hash, e.uncompressed_len, e.compressed_len);
+        //fprintf(stdout, "%s,%08x,%08x,%" PRIu64 ",%08x,%zu,%zu\n", n.c_str(), e.ph, e.sh, e.timestamp, e.hash, e.uncompressed_len, e.compressed_len);
     };
 
     fclose(fp);
@@ -719,7 +718,7 @@ int mft_diff(mft_product &prod)
         {
             fprintf(
                 fp,
-                "%s,%lu,%08x,%zu,%zu,0,0\n",
+                "%s,%" PRIu64 ",%08x,%zu,%zu,0,0\n",
                 e.name,
                 e.timestamp,
                 e.hash,
@@ -754,7 +753,7 @@ int mft_diff(mft_product &prod)
         {
             fprintf(
                 stdout,
-                "%s,%lu,%08x,%zu,%zu,%08x,%u\n",
+                "%s,%" PRIu64 ",%08x,%zu,%zu,%08x,%u\n",
                 e.name,
                 e.timestamp,
                 e.hash,
@@ -938,7 +937,7 @@ mft_result mft_product_install(mft_config &cfg, const char *product_url, const c
         prod.config.dump_extracted = false;
         if (FILE *fp = fopen(fs_path_ascii(latest_file), "rb"))
         {
-            fscanf(fp, "%lu", &prod.last_version);
+            fscanf(fp, "%" PRIu64 "", &prod.last_version);
             fclose(fp);
         }
         else
@@ -1038,7 +1037,7 @@ mft_result mft_product_install(mft_config &cfg, const char *product_url, const c
         {
             if (FILE *fp = fopen(fs_path_ascii(latest_file), "wb"))
             {
-                fprintf(fp, "%lu", prod.timestamp);
+                fprintf(fp, "%" PRIu64 "", prod.timestamp);
                 fclose(fp);
             }
         }
@@ -1113,8 +1112,8 @@ int main(int argc, char **argv)
 
     if (s_cli["xuo"].was_set())
     {
-        xuo_update_apply(outpath);
-        return 0;
+        auto ctx = xuo_init(outdir, false);
+        return xuo_update_apply(ctx);
     }
 
     const char *product_urls[] = { DATA_PATCHER_SERVER_ADDRESS, DATA_PRODUCT_SERVER_ADDRESS };

--- a/tools/xuoi/xuo_updater.cpp
+++ b/tools/xuoi/xuo_updater.cpp
@@ -1,0 +1,377 @@
+#include <vector>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <inttypes.h>
+#include <algorithm>
+
+#include <external/xxhash.h>
+#include <external/tinyxml2.h>
+#include <external/miniz.h>
+
+//#define LOG_DEBUG(...) // comment to enable debug logging
+//#define LOG_TRACE(...) // comment to enable tracing
+#include <common/fs.h>
+#include <common/log.h>
+
+#include "http.h"
+
+#define XUOL_VERSION "1.1"
+#define XUOL_AGENT_NAME "X:UO Launcher v" XUOL_VERSION
+#define XUOL_UPDATER_HOST "http://update.crossuo.com/"
+//#define UPDATER_HOST "http://192.168.2.14:8089/"
+
+#define XUOL_THREADED 0
+#if XUOL_THREADED
+#include <atomic>
+#include <thread>
+#define XUOL_ATOMIC(x) std::atomic<x>
+#define XUOL_ATOMIC_ADD(x, i) (x.fetch_add(i))
+#define XUOL_THREAD_COUNT (std::thread::hardware_concurrency() - 1)
+#else
+#define XUOL_ATOMIC(x) x
+#define XUOL_ATOMIC_ADD(x, i) (x + i)
+#define XUOL_THREAD_COUNT (1)
+#endif
+
+enum class xuo_channel : uint8_t
+{
+    stable,
+    beta,
+};
+
+enum xuo_result
+{
+    xuo_ok,
+    xuo_invalid_manifest,
+    xuo_checksum_failed,
+    xuo_could_not_open_path,
+    xuo_could_not_write_file,
+    xuo_could_not_deflate_file,
+    xuo_could_not_copy_file,
+    xuo_install_failed,
+};
+
+struct xuo_file
+{
+    const char *name = nullptr;
+    const char *zipFilename = nullptr;
+    uint64_t hash = 0;
+    uint64_t zipHash = 0;
+    bool launcher = false;
+    bool executable = false;
+};
+
+struct xuo_release
+{
+    const char *name = nullptr;
+    const char *version = nullptr;
+    bool latest = false;
+    std::vector<xuo_file> files;
+};
+
+struct xuo_context
+{
+    const char *platform;
+    fs_path cache_path;
+    fs_path output_path;
+
+    std::vector<xuo_release> releases;
+    std::vector<uint8_t> changelog;
+    std::vector<uint8_t> manifest;
+    tinyxml2::XMLDocument doc;
+};
+
+#if 1 //defined(XUO_LINUX)
+static const char *s_distroName = nullptr;
+
+const char *xuo_platform_name()
+{
+    if (s_distroName != nullptr)
+        return s_distroName;
+
+    static char distroName[128] = {};
+    char buf[512] = {};
+    const char *distro = nullptr;
+    s_distroName = "ubuntu";
+    if (FILE *fp = fopen("/etc/lsb-release", "rt"))
+    {
+        while (!feof(fp))
+        {
+            if (!fgets(buf, sizeof(buf), fp))
+                break;
+            char *sep = strchr(buf, '=');
+            if (!sep)
+                continue;
+
+            *sep++ = '\0';
+            if (strcmp(buf, "DISTRIB_ID") != 0)
+                continue;
+
+            distro = sep;
+            for (int i = 0; distro[i] != 0 && distro[i] != '\n' && distro[i] != '\r'; ++i)
+            {
+                distroName[i] = tolower(distro[i]);
+            }
+            s_distroName = distroName;
+            break;
+        }
+        fclose(fp);
+    }
+
+    if (strcmp(s_distroName, "manjarolinux") != 0 && strcmp(s_distroName, "ubuntu") != 0)
+    {
+        LOG_WARN(
+            "The %s distribution is unsupported, you may find issues trying to use this binary",
+            distro);
+    }
+
+    return s_distroName;
+}
+#elif defined(XUO_MACOS)
+const char *xuo_platform_name()
+{
+    return "osx";
+}
+#else  // MACOS
+const char *xuo_platform_name()
+{
+    return "win64";
+}
+#endif // WIN64
+
+static fs_path s_cachePath;
+
+void xuo_set_cache_directory(const char *cachePath)
+{
+    s_cachePath = fs_path_from(cachePath);
+    fs_path_create(s_cachePath);
+}
+
+static uint64_t xuo_get_hash(const fs_path &filename)
+{
+    size_t len = 0;
+    auto ptr = fs_map(filename, &len);
+    auto hash = XXH64(static_cast<void *>(ptr), len, 0x2593);
+    fs_unmap(ptr, len);
+
+    return hash;
+}
+
+void xuo_changelog_load(xuo_context &ctx)
+{
+    const char *changelog_addr = XUOL_UPDATER_HOST "release/changelog.html";
+    static std::vector<uint8_t> changelog_file;
+    if (changelog_file.empty())
+        http_get_binary(changelog_addr, changelog_file);
+    ctx.changelog = changelog_file;
+}
+
+static xuo_result xuo_release_load(xuo_context &ctx, tinyxml2::XMLElement *node)
+{
+    xuo_release rel;
+    rel.name = node->Attribute("name");
+    rel.version = node->Attribute("version");
+    rel.latest = node->BoolAttribute("latest", false);
+    LOG_TRACE("# release: %s version: %s (latest: %d)\n", rel.name, rel.version, rel.latest);
+    auto fnode = node->FirstChildElement("file");
+    while (fnode)
+    {
+        xuo_file file;
+        file.name = fnode->Attribute("name");
+        file.executable = fnode->BoolAttribute("exe", false);
+        file.hash = fnode->Hex64Attribute("hash", 0);
+        file.zipFilename = fnode->Attribute("data");
+        file.zipHash = fnode->Hex64Attribute("datahash", 0);
+        LOG_TRACE(
+            "  file: %s hash: %" PRIx64 " at %s (%" PRIx64 ")\n",
+            file.name,
+            file.hash,
+            file.zipFilename,
+            file.zipHash);
+        // workaround for backwards compat with older manifest version
+        if (!file.executable)
+        {
+            if (!strcasecmp(file.name, "crossuo"))
+                file.executable = true;
+            if (!strcasecmp(file.name, "xuolauncher"))
+                file.executable = true;
+            if (!strcasecmp(file.name, "xuoassist"))
+                file.executable = true;
+        }
+        rel.files.emplace_back(file);
+        fnode = fnode->NextSiblingElement("file");
+    }
+    ctx.releases.emplace_back(rel);
+    return xuo_ok;
+}
+
+static xuo_result xuo_manifest_load(xuo_context &ctx, const char *platform, xuo_channel channel)
+{
+    const char *manifest_addr = XUOL_UPDATER_HOST "release/%s%s.manifest.xml";
+    char addr[512];
+    snprintf(
+        addr, sizeof(addr), manifest_addr, platform, channel == xuo_channel::beta ? "-beta" : "");
+    http_get_binary(addr, ctx.manifest);
+    ctx.platform = platform;
+    ctx.doc.Parse((char *)ctx.manifest.data(), ctx.manifest.size());
+    auto root = ctx.doc.FirstChildElement("manifest");
+    if (!root)
+        return xuo_invalid_manifest;
+
+    auto release = root->FirstChildElement("release");
+    while (release)
+    {
+        xuo_release_load(ctx, release);
+        release = release->NextSiblingElement("release");
+    }
+    return xuo_ok;
+}
+
+static xuo_result xuo_update_file(xuo_context &ctx, xuo_release &rel, xuo_file &file)
+{
+    fs_path ipath = fs_join_path(ctx.cache_path, file.zipFilename);
+    fs_path idir = fs_directory(ipath);
+    if (!fs_path_create(idir))
+    {
+        LOG_ERROR("failed to create directory: %s\n", fs_path_ascii(idir));
+        return xuo_could_not_open_path;
+    }
+
+    fs_path opath = fs_join_path(ctx.output_path, file.name);
+    fs_path odir = fs_directory(opath);
+    if (!fs_path_create(odir))
+    {
+        LOG_ERROR("failed to create directory: %s\n", fs_path_ascii(odir));
+        return xuo_could_not_open_path;
+    }
+
+    char upath[512] = {};
+    snprintf(upath, sizeof(upath), XUOL_UPDATER_HOST "update/%s", file.zipFilename);
+
+    auto lpath = fs_path_ascii(ipath);
+    if (!fs_path_exists(ipath))
+    {
+        if (!http_get_file(upath, lpath))
+            return xuo_could_not_write_file;
+    }
+
+    auto icrc = xuo_get_hash(ipath);
+    if (icrc != file.zipHash)
+        return xuo_checksum_failed;
+
+    mz_zip_archive zip;
+    memset(&zip, 0, sizeof(zip));
+    mz_bool status = mz_zip_reader_init_file(&zip, lpath, 0);
+    if (!status)
+        return xuo_could_not_deflate_file;
+
+    if (mz_zip_reader_get_num_files(&zip) != 1)
+        return xuo_could_not_deflate_file;
+
+    status = mz_zip_reader_extract_to_file(&zip, 0, fs_path_ascii(opath), 0);
+    mz_zip_reader_end(&zip);
+    if (!status)
+        return xuo_could_not_deflate_file;
+
+    auto ocrc = xuo_get_hash(opath);
+    if (ocrc != file.hash)
+    {
+        fs_del(opath);
+        return xuo_checksum_failed;
+    }
+
+    if (file.executable)
+        fs_chmod(opath, fs_mode(FS_READ | FS_WRITE | FS_EXEC));
+
+    return xuo_ok;
+}
+
+static bool xuo_install_release(xuo_context &ctx, xuo_release &release)
+{
+    XUOL_ATOMIC(uint32_t) errors{ 0 };
+    const uint32_t threads = XUOL_THREAD_COUNT;
+
+#if XUOL_THREADED
+    std::vector<std::thread> jobs;
+#endif
+
+    for (uint32_t tid = 0; tid < threads; ++tid)
+    {
+        auto job = [tid, &errors, &ctx, &release]() {
+            for (auto i = tid; i < release.files.size(); i += threads)
+            {
+                if (xuo_update_file(ctx, release, release.files[i]) != xuo_ok)
+                {
+                    errors = XUOL_ATOMIC_ADD(errors, 1);
+                }
+            }
+        };
+#if XUOL_THREADED
+        jobs.push_back(std::thread(job));
+#else
+        job();
+#endif
+    }
+
+#if XUOL_THREADED
+    for (auto &job : jobs)
+    {
+        job.join();
+    }
+#endif
+
+    return errors == 0 ? xuo_ok : xuo_install_failed;
+}
+
+void xuo_update_generate()
+{
+}
+
+xuo_release *xuo_release_get(xuo_context &ctx, const char *name, const char *version = nullptr)
+{
+    auto it = std::find_if(
+        ctx.releases.begin(), ctx.releases.end(), [name, version](xuo_release &e) -> bool {
+            if (strcasecmp(e.name, name) == 0)
+            {
+                if (version == nullptr && e.latest)
+                    return true;
+                if (version && strcasecmp(e.version, version) == 0)
+                    return true;
+            }
+            return false;
+        });
+    if (it == ctx.releases.end())
+        return nullptr;
+    return &(*it);
+}
+
+bool xuo_update_apply(const fs_path &path)
+{
+    xuo_context ctx;
+    http_set_user_agent(XUOL_AGENT_NAME);
+    xuo_changelog_load(ctx);
+    if (xuo_manifest_load(ctx, xuo_platform_name(), xuo_channel::stable))
+        return false;
+
+    ctx.cache_path = fs_join_path(fs_appdata_path(), "xuolauncher_", "cache");
+    ctx.output_path = path;
+
+    fs_path dir = fs_directory(ctx.cache_path);
+    if (!fs_path_create(dir))
+    {
+        LOG_ERROR("failed to create directory: %s\n", fs_path_ascii(dir));
+        return false;
+    }
+
+    dir = fs_directory(ctx.output_path);
+    if (!fs_path_create(dir))
+    {
+        LOG_ERROR("failed to create directory: %s\n", fs_path_ascii(dir));
+        return false;
+    }
+
+    auto rel = xuo_release_get(ctx, "CrossUO", "1.0.0");
+    return rel ? xuo_install_release(ctx, *rel) : false;
+}

--- a/tools/xuoi/xuo_updater.h
+++ b/tools/xuoi/xuo_updater.h
@@ -1,6 +1,13 @@
+// GPLv3 License
+// Copyright (c) 2019 Danny Angelo Carminati Grein
+
 #pragma once
 
-#include <common/fs.h>
+struct xuo_context;
 
+xuo_context *xuo_init(const char *path, bool beta);
 const char *xuo_platform_name();
-bool xuo_update_apply(const fs_path &outpath);
+const char *xuo_changelog(xuo_context *ctx);
+bool xuo_update_check(xuo_context *ctx);
+bool xuo_update_apply(xuo_context *ctx);
+void xuo_shutdown(xuo_context *ctx);

--- a/tools/xuoi/xuo_updater.h
+++ b/tools/xuoi/xuo_updater.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <common/fs.h>
+
+const char *xuo_platform_name();
+bool xuo_update_apply(const fs_path &outpath);


### PR DESCRIPTION
Implements the updater/installer module from X:UO Launcher as an
independent implementation to be reused/adapted as needed.

This is a first step towards an unified installer and tooling and
removing Qt as a dependency.

Some improvements to the fs.h utility:
- fs_copy file copying
- fs_del file deletion
- fs_chmod permissions manipulation
- fs_file_read utils
- fs_file_wrie utils

Separate http functions, add a helper function to download directly to
file instead of memory buffers