### PR TITLE
Client: add more information on why client failed to launch

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -363,15 +363,15 @@ static fs_path GetConfigFile()
 
 bool LoadGlobalConfig()
 {
-    const auto cfg = GetConfigFile();
+    auto cfg = GetConfigFile();
     Info(Config, "loading global config from: %s", fs_path_ascii(cfg));
     if (!fs_path_exists(cfg))
     {
-        Fatal(
-            Config,
-            "Could not load config file, try using X:UO Launcher.",
-            "failed to load: %s",
-            fs_path_ascii(cfg));
+        cfg = fs_path_join(fs_path_current(), cfg);
+    }
+
+    if (!fs_path_exists(cfg))
+    {
         return false;
     }
 
@@ -520,17 +520,10 @@ bool LoadGlobalConfig()
     Info(Client, "\tUse Verdata: %d", g_Config.UseVerdata);
     const auto uopath = fs_path_ascii(g_App.m_UOPath);
     Info(Client, "\tUltima Online Path: %s", uopath);
-
-    if ((uopath && !uopath[0]) || !fs_path_exists(g_App.m_UOPath))
+    if (uopath && uopath[0] && fs_path_exists(g_App.m_UOPath))
     {
-        Fatal(
-            Config,
-            "Couldn't find Ultima Online(tm) data files.",
-            "could not find data path: %s",
-            uopath);
-        return false;
+        uo_data_init(uopath, g_Config.ClientVersion, g_Config.UseVerdata);
     }
-    uo_data_init(uopath, g_Config.ClientVersion, g_Config.UseVerdata);
     return true;
 }
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <common/str.h>
+#include <common/fs.h>
 #include <xuocore/enumlist.h>
 
 struct Config


### PR DESCRIPTION
The biggest sources of technical support on the client are
users having difficulties launching the client for these reasons:
- No config was set
- No original client data found
- A config is found, but no valid client data is set/found

This tries to help differentiating the reasons above and try to help
users to fix the issues our a bit more detailed error message box.

If there is no config, the client will try to launch X:UO launcher and
hopefully the user will understand that a configuration is needed - more
help should be done in the launcher, as pointing to a website
documentation.
If then no launcher is found, the client will open the browser in the
crossuo website in the download section and ask the user to download the
launcher, which should be from now on always together with the CrossUO
client.
If the config is found, the client will try to validate that the UO data
path set in the config is correct and pop a message box explaining
and/or loading the X:UO Launcher.