### PR TITLE
xuolauncher: move all settings to the appdata/xuolauncher path

### DIFF
--- a/common/logging/logging.h
+++ b/common/logging/logging.h
@@ -63,6 +63,16 @@ extern fatalErrorCb g_fatalErrorCb;
         LOG_(system, FATAL, __VA_ARGS__);                                                          \
     } while (0);
 
+#define ErrorMessage(system, friendly_msg, ...)                                                    \
+    do                                                                                             \
+    {                                                                                              \
+        if (g_fatalErrorCb)                                                                        \
+        {                                                                                          \
+            g_fatalErrorCb(friendly_msg);                                                          \
+        }                                                                                          \
+        LOG_(system, ERROR, __VA_ARGS__);                                                          \
+    } while (0);
+
 #define INFO_DUMP(system, ...) LOG_DUMP_(system, 0, __VA_ARGS__)
 
 #if defined(XUO_DEBUG)

--- a/external/ass.h
+++ b/external/ass.h
@@ -35165,11 +35165,12 @@ namespace SoLoud
 
 	result Queue::setParams(float aSamplerate, unsigned int aChannels)
 	{
-	    if (aChannels < 1 || aChannels > MAX_CHANNELS)
-	        return INVALID_PARAMETER;
+		if (aChannels < 1 || aChannels > MAX_CHANNELS)
+			return INVALID_PARAMETER;
+
 		mChannels = aChannels;
 		mBaseSamplerate = aSamplerate;
-	    return SO_NO_ERROR;
+		return SO_NO_ERROR;
 	}
 };
 // file: soloud/src/core\soloud_thread.cpp

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -136,7 +136,7 @@ bool load_config()
     if (!config_exists && !launcher_exists)
     {
         Platform::OpenBrowser("https://crossuo.com/#download");
-        Fatal(
+        ErrorMessage(
             Client,
             "You need X:UO Launcher to launch CrossUO.\n"
             "Please download from https://crossuo.com/#download",
@@ -152,7 +152,7 @@ bool load_config()
         const auto options = process_option_inherit_environment | process_option_child_detached;
         if (process_create(args, options, &process) != 0)
         {
-            Fatal(Client, "Could not launch X:UO Launcher", "could not launch: %s", bin);
+            ErrorMessage(Client, "Could not launch X:UO Launcher", "could not launch: %s", bin);
         }
         SDL_Delay(500);
     };
@@ -173,7 +173,7 @@ bool load_config()
             {
                 launcher();
             }
-            Fatal(
+            ErrorMessage(
                 Client,
                 "Couldn't find Ultima Online(tm) data files.\n"
                 "Please download the original ultima client and configure CrossUO to use the "
@@ -223,7 +223,7 @@ bool load_config()
             {
                 launcher();
             }
-            Fatal(
+            ErrorMessage(
                 Client,
                 "Couldn't find valid Ultima Online(tm) data files for current configuration.\n"
                 "Make sure your configuration is pointing to the correct data files for the\n"
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
 
     if (SDL_Init(SDL_INIT_TIMER) < 0)
     {
-        Fatal(
+        ErrorMessage(
             Client,
             "Window initialization failure.",
             "unable to initialize SDL %s",
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
         {
             const char *errMsg =
                 "Failed to create CrossUO client window. May be caused by a missing configuration file.";
-            Fatal(Client, errMsg, "error initializing game window");
+            ErrorMessage(Client, errMsg, "error initializing game window");
             return -1;
         }
     }

--- a/tools/xuoi/shards.cpp
+++ b/tools/xuoi/shards.cpp
@@ -12,6 +12,7 @@
 
 extern bool valid_url(const astr_t &url);
 extern void open_url(const astr_t &url);
+extern const fs_path &xuol_data_path();
 
 namespace shard
 {
@@ -238,11 +239,13 @@ void load_shards()
     auto custom = shard::default_entry();
     custom.shard_name = "<custom shard>";
     s_shards.entries.emplace_back(custom);
-    const auto fname = fs_path_join(fs_path_current(), "shards.cfg");
 #if !defined(VALIDATOR)
+    const auto fname = fs_path_join(xuol_data_path(), "shards.cfg");
     http_get_file(
         "https://github.com/crossuo/shards/releases/download/latest/shards.cfg",
         fs_path_ascii(fname));
+#else
+    const auto fname = fs_path_join(fs_path_current(), "shards.cfg");
 #endif
     load_shard_file(fname, s_shards);
 

--- a/tools/xuoi/xuo_updater.cpp
+++ b/tools/xuoi/xuo_updater.cpp
@@ -405,7 +405,7 @@ xuo_context *xuo_init(const char *path, bool beta)
         return nullptr;
     }
 
-    ctx.config.cache_path = fs_path_join(fs_appdata_path(), "xuolauncher", "cache");
+    ctx.config.cache_path = fs_path_join(fs_path_appdata(), "xuolauncher", "cache");
     ctx.config.output_path = fs_path_from(path);
 
     fs_path dir = ctx.config.cache_path;

--- a/tools/xuoi/xuolauncher.cpp
+++ b/tools/xuoi/xuolauncher.cpp
@@ -292,6 +292,24 @@ static inline bool ui_modal(const char *title, const char *msg)
     return yes;
 }
 
+const fs_path &xuol_data_path()
+{
+    static bool initialized = false;
+    static fs_path dir;
+    if (initialized)
+        return dir;
+
+    dir = fs_path_join(fs_path_appdata(), "xuolauncher");
+    if (!fs_path_create(dir))
+    {
+        LOG_ERROR("failed to create directory: %s", fs_path_ascii(dir));
+        return dir;
+    }
+
+    initialized = true;
+    return dir;
+}
+
 #define CFG_NAME launcher
 #define CFG_SECTION_FILTER_NAME "global"
 #define CFG_DEFINITION "cfg_launcher.h"
@@ -306,7 +324,8 @@ launcher::entry &config()
 
 void load_config()
 {
-    const auto fname = fs_path_join(fs_path_current(), "xuolauncher.cfg");
+    const auto fname = fs_path_join(xuol_data_path(), "xuolauncher.cfg");
+
     LOG_INFO("loading settings from %s", fs_path_ascii(fname));
     auto fp = fs_open(fname, FS_READ);
     launcher::cfg(fp, s_config);
@@ -327,7 +346,7 @@ void write_config(void *_fp)
 
 void save_config()
 {
-    const auto fname = fs_path_join(fs_path_current(), "xuolauncher.cfg");
+    const auto fname = fs_path_join(xuol_data_path(), "xuolauncher.cfg");
     auto fp = fs_open(fname, FS_WRITE);
     if (!fp)
     {
@@ -346,24 +365,6 @@ void xuol_launch_quit()
 }
 
 static ui_model model;
-
-const fs_path &xuol_data_path()
-{
-    static bool initialized = false;
-    static fs_path dir;
-    if (initialized)
-        return dir;
-
-    dir = fs_path_join(fs_appdata_path(), "xuolauncher");
-    if (!fs_path_create(dir))
-    {
-        LOG_ERROR("failed to create directory: %s", fs_path_ascii(dir));
-        return dir;
-    }
-
-    initialized = true;
-    return dir;
-}
 
 #if !defined(XUO_DEBUG)
 static bool run_self_update_instance(int argc, char **argv)


### PR DESCRIPTION
fs.h: add fs_path_process() to get the path of the current executing
process, differently from fs_path_current() which is the current workdir
for the process. This will help solve issues with launching crossuo from
an osx app package.