### PR TITLE
Fix typo which prevents binding Consecrate Weapon spell

### DIFF
--- a/src/Macro.cpp
+++ b/src/Macro.cpp
@@ -552,7 +552,7 @@ const char *CMacro::m_MacroAction[MACRO_ACTION_COUNT] = {
     "Exorcism",
     "Cleanse By Fire",
     "Close Wounds",
-    "Concentrate Weapon",
+    "Consecrate Weapon",
     "Dispel Evil",
     "Divine Fury",
     "Enemy Of One",


### PR DESCRIPTION
Minor typo which lists the spell as Concentrate Weapon prevented binding the spell as a macro.