### PR TITLE
Improve first time experience when building crossuo from source

### DIFF
--- a/.github/package.cmd
+++ b/.github/package.cmd
@@ -1,8 +1,14 @@
 :: SPDX-License-Identifier: AGPL-3.0-or-later
 :: SPDX-FileCopyrightText: 2020 Danny Angelo Carminati Grein
 
-echo Building %GITHUB_REF_NAME% package
-md crossuo-win64-%GITHUB_REF_NAME%
-copy build\src\Release\crossuo.exe crossuo-win64-%GITHUB_REF_NAME%\crossuo.exe
-copy build\tools\xuoi\Release\xuolauncher.exe crossuo-win64-%GITHUB_REF_NAME%\xuolauncher.exe
-7z a crossuo-win64-%GITHUB_REF_NAME%.zip crossuo-win64-v%GITHUB_REF_NAME%\
+if %GITHUB_REF_NAME% == master (
+  set BUILD=v%GITHUB_REF_NAME%
+) else (
+  set BUILD=master
+)
+
+echo Building %BUILD% package
+md crossuo-win64-%BUILD%
+copy build\src\Release\crossuo.exe crossuo-win64-%BUILD%\crossuo.exe
+copy build\tools\xuoi\Release\xuolauncher.exe crossuo-win64-%BUILD%\xuolauncher.exe
+7z a crossuo-win64-%BUILD%.zip crossuo-win64-%BUILD%\

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 # CrossUO Client
 
 [![build](https://github.com/crossuo/crossuo/actions/workflows/build.yml/badge.svg)](https://github.com/crossuo/crossuo/actions/workflows/build.yml)
+[![REUSE status](https://api.reuse.software/badge/github.com/crossuo/crossuo)](https://api.reuse.software/info/github.com/crossuo/crossuo)
 
 CrossUO is a cross-platform Ultima Online client in active development.
 

--- a/src/CharacterList.h
+++ b/src/CharacterList.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <common/str.h>
 
 class CCharacterList

--- a/tools/xuoi/CMakeLists.txt
+++ b/tools/xuoi/CMakeLists.txt
@@ -61,6 +61,11 @@ target_link_libraries(${XUOL_PROJECT} PUBLIC ${XUOCORE_PROJECT} ${CURL_LIBRARIES
 target_include_directories(${XUOL_PROJECT} PUBLIC ${XUOCORE_PROJECT} ${EXTERNALGFX_INCLUDE})
 xuo_disable_console(${XUOL_PROJECT})
 
+add_custom_command(TARGET ${XUOL_PROJECT} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${XUOL_PROJECT}> ${PROJECT_BINARY_DIR}/../../src/${XUOL_PROJECT}
+  COMMENT "Copied ${PROJECT_BINARY_DIR}/../../src/${XUOL_PROJECT}"
+)
+
 #
 # shardchk
 #

--- a/xuocore/uop.h
+++ b/xuocore/uop.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <common/str.h>
 
 #define UOP_HASH(ph, sh) static_cast<uint64_t>(((uint64_t(ph) << 32) | sh))


### PR DESCRIPTION
CI: REUSE badge and windows package script improvement

Fix compilation error
- Added missing stdint.h header

Improve first time experience when building crossuo from source

Add a post-build step to copy xuolauncher to the same directory as the
crossuo client to improve the first time experience after building the
code from source. The reason is that once you build and try to launch
the client, there is no configuration file so crossuo will try to start
the launcher itself to create a new configuration. The client expects
the launcher to be on the same directory.